### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A web app for those who love hanging out in the forest but always forget to brin
 * [packflare.com](https://packflare.com/packs/zdihojtsew) (sign-up doesn't work)
 * [hikepack.app](https://www.hikepack.app/list/84a8ea0c-006b-4cff-bb2b-7bcf52183b0b) (simple TODO list)
 * [packstack.io](https://www.packstack.io/) (Bad UX)
-* [Don't Forget the Spoon](https://play.google.com/store/apps/details?id=com.dontforgetthespoon.dont_forget_the_spoon&hl=en_US&pli=1) (Adnroid, featureless)
+* [Don't Forget the Spoon](https://play.google.com/store/apps/details?id=com.dontforgetthespoon.dont_forget_the_spoon&hl=en_US&pli=1) (Android, featureless)
 * ~~geargrams.com~~ (dead)
 * ~~trailhawk.io~~ (dead)
 * ~~baseweight.co~~ (dead)


### PR DESCRIPTION
## Summary
- fix a small typo for the Android app mention in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f4fcc97c08325a1c7da6bfd5bdd32