### PR TITLE
Update brand creation errors

### DIFF
--- a/server/api/brands/index.post.ts
+++ b/server/api/brands/index.post.ts
@@ -41,7 +41,7 @@ export default defineEventHandler(async (event) => {
       })
 
     if (inserted === undefined) {
-      throw new Error('Failed to create equipment type')
+      throw new Error('Failed to create brand')
     }
 
     setResponseStatus(event, 201)
@@ -52,7 +52,7 @@ export default defineEventHandler(async (event) => {
 
     throw createError({
       statusCode: 400,
-      message: 'Failed to create equipment type'
+      message: 'Failed to create brand'
     })
   }
 })


### PR DESCRIPTION
## Summary
- fix error messages in `server/api/brands/index.post.ts`

## Testing
- `npm run typecheck` *(fails: nuxi not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4fdc457083259168c8ad0a748799