### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/database-migration-staging.yml
+++ b/.github/workflows/database-migration-staging.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'server/database/migrations/**'
 
+permissions:
+  contents: read
+
 jobs:
   migration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Perdolique/perd/security/code-scanning/2](https://github.com/Perdolique/perd/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Since the workflow does not appear to interact with the repository contents beyond potentially reading them, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
