### PR TITLE
Use automations v2 workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,8 +21,14 @@ concurrency:
 
 jobs:
   deploy:
-    uses: Perdolique/automations/.github/workflows/deploy.yml@v1.0.4
+    uses: Perdolique/automations/.github/workflows/deploy.yml@v2
+    with:
+      test-typecheck-command: test:typecheck
+      lint-markdown-command: lint:markdown
+      lint-oxlint-command: lint:oxlint
+      test-unit-command: test:unit:ci
+      deploy-to-staging-command: deploy:versions:staging
+      deploy-to-production-command: deploy:production
     secrets:
       cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-

--- a/.github/workflows/database-migration.yml
+++ b/.github/workflows/database-migration.yml
@@ -19,9 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ github.event_name == 'pull_request' && 'staging' || 'production' }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - uses: Perdolique/automations/.github/actions/setup-pnpm@v1.0.4
+      - uses: Perdolique/automations/.github/actions/setup-pnpm@v2
         with:
           install-dependencies: true
       - name: Run database migration


### PR DESCRIPTION
## Summary
- 🔧 Switch the deploy workflow to `Perdolique/automations/.github/workflows/deploy.yml@v2`
- 🧪 Pass the project-specific validation and deploy commands into the reusable deploy workflow
- ♻️ Update the database migration workflow to use `Perdolique/automations/.github/actions/setup-pnpm@v2`

## Motivation
- 🚀 Keep this repository aligned with the shared automation v2 contract
- 🛠️ Remove workflow-local setup that is now handled by the shared automation
- ✅ Ensure deploy and migration jobs run the commands expected by this project

## Testing
- `pnpm run lint:markdown`
- `pnpm run lint:oxlint`
- `pnpm run test:typecheck`
- `pnpm run test:unit:ci`
- `pnpm run build`
- `pnpm run test:e2e:ci`

## Related Issues
- None
