### PR TITLE
Add user gear submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,26 @@ Perd is an outdoor equipment companion for people who plan trips, hikes, and oth
 
 ## What you can do now
 
-- sign in;
-- open the catalog;
-- browse the current list of equipment;
-- open item detail pages;
-- keep a personal inventory with "I have this" actions;
-- create packing lists for specific trips or activities;
-- add custom and inventory-backed checklist entries;
-- mark checklist entries as packed.
+- Sign in.
+- Browse equipment.
+- View item details.
+- Save gear.
+- Create packing lists.
+- Add checklist items.
+- Mark items packed.
 
-The priority is the user workflow, not internal admin tooling.
+## TODO
+
+- Catalog search.
+- Catalog filters.
+- Gear submissions.
+- Better item details.
+- Pack renaming.
+- Pack weight totals.
+- Pack duplication.
+- Pack sharing.
+- Pack export.
+- Twitch account linking.
 
 ## Similar applications
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Perd is an outdoor equipment companion for people who plan trips, hikes, and oth
 - Browse equipment.
 - View item details.
 - Save gear.
+- Submit gear for review and use it in your inventory immediately.
 - Create packing lists.
 - Add checklist items.
 - Mark items packed.
@@ -18,7 +19,6 @@ Perd is an outdoor equipment companion for people who plan trips, hikes, and oth
 
 - Catalog search.
 - Catalog filters.
-- Gear submissions.
 - Better item details.
 - Pack renaming.
 - Pack weight totals.

--- a/app/components/dialogs/ModalDialog.vue
+++ b/app/components/dialogs/ModalDialog.vue
@@ -14,9 +14,13 @@
 
   interface Props {
     closeDisabled?: boolean;
+    overlayCloseDisabled?: boolean;
   }
 
-  const { closeDisabled = false } = defineProps<Props>()
+  const {
+    closeDisabled = false,
+    overlayCloseDisabled = false
+  } = defineProps<Props>()
   const dialogRef = useTemplateRef('dialogRef')
 
   const isOpened = defineModel<boolean>({
@@ -35,9 +39,9 @@
     isOpened.value = false
   })
 
-  // Close the dialog when clicking outside of it
+  // Close the dialog when clicking the backdrop.
   useEventListener(dialogRef, 'click', ({ target }: MouseEvent) => {
-    if (closeDisabled) {
+    if (closeDisabled || overlayCloseDisabled) {
       return
     }
 

--- a/app/components/equipment/EquipmentItemSubmissionDialog.vue
+++ b/app/components/equipment/EquipmentItemSubmissionDialog.vue
@@ -1,0 +1,51 @@
+<template>
+  <ModalDialog
+    v-model="isOpened"
+    :close-disabled="isSubmitting"
+    aria-labelledby="gear-submission-dialog-title"
+    overlay-close-disabled
+  >
+    <EquipmentItemSubmissionForm
+      form-id="equipment-submission"
+      heading-id="gear-submission-dialog-title"
+      :active="isOpened"
+      show-cancel-button
+      show-close-button
+      show-full-page-link
+      show-header
+      submit-label="Create now"
+      variant="dialog"
+      @close="close"
+      @submitted="handleSubmitted"
+      @submitting="handleSubmitting"
+    />
+  </ModalDialog>
+</template>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+  import type { ItemSubmissionCreateResponse } from '~/types/equipment'
+  import ModalDialog from '~/components/dialogs/ModalDialog.vue'
+  import EquipmentItemSubmissionForm from '~/components/equipment/EquipmentItemSubmissionForm.vue'
+
+  type Emits = (event: 'submitted', response: ItemSubmissionCreateResponse) => void
+
+  const emit = defineEmits<Emits>()
+  const isOpened = defineModel<boolean>({
+    required: true
+  })
+  const isSubmitting = ref(false)
+
+  function close() {
+    isOpened.value = false
+  }
+
+  function handleSubmitted(response: ItemSubmissionCreateResponse) {
+    emit('submitted', response)
+    close()
+  }
+
+  function handleSubmitting(submitting: boolean) {
+    isSubmitting.value = submitting
+  }
+</script>

--- a/app/components/equipment/EquipmentItemSubmissionForm.vue
+++ b/app/components/equipment/EquipmentItemSubmissionForm.vue
@@ -1,0 +1,790 @@
+<template>
+  <form
+    ref="formRef"
+    :class="[$style.component, variant]"
+    action="/api/equipment/item-submissions"
+    method="post"
+    @submit.prevent="handleSubmit"
+  >
+    <div v-if="showHeader" :class="$style.header">
+      <div :class="$style.headingBlock">
+        <div :class="$style.kicker">
+          Gear submission
+        </div>
+
+        <PerdHeading
+          :id="headingId"
+          :class="$style.heading"
+          :level="2"
+        >
+          Add gear
+        </PerdHeading>
+      </div>
+
+      <button
+        v-if="showCloseButton"
+        type="button"
+        :class="$style.closeButton"
+        :disabled="isSubmitting"
+        aria-label="Close gear submission dialog"
+        @click="emitClose"
+      >
+        <Icon name="tabler:x" aria-hidden="true" />
+      </button>
+    </div>
+
+    <p :class="$style.description">
+      The item goes into your inventory now. It appears in the public catalog after review.
+    </p>
+
+    <p v-if="isReferenceLoading" :class="$style.helperMessage" role="status">
+      Loading catalog options.
+    </p>
+
+    <div v-else-if="hasReferenceError" :class="$style.errorPanel" role="alert">
+      <p :class="$style.errorMessage">
+        Could not load catalog options.
+      </p>
+
+      <PerdButton variant="secondary" size="small" @click="loadReferenceData">
+        Retry
+      </PerdButton>
+    </div>
+
+    <div v-else :class="$style.fields">
+      <div :class="$style.field">
+        <label :class="$style.inputLabel" :for="nameInputId">
+          Item name
+        </label>
+
+        <input
+          :id="nameInputId"
+          ref="nameInput"
+          v-model="itemName"
+          :class="$style.input"
+          :disabled="isSubmitting"
+          :maxlength="limits.maxEquipmentItemNameLength"
+          name="name"
+          autocomplete="off"
+          required
+        >
+      </div>
+
+      <div :class="$style.field">
+        <label :class="$style.inputLabel" :for="brandInputId">
+          Brand
+        </label>
+
+        <select
+          :id="brandInputId"
+          v-model="selectedBrandId"
+          :class="$style.input"
+          :disabled="isSubmitting"
+          name="brandId"
+          required
+        >
+          <option value="">
+            Select a brand
+          </option>
+
+          <option
+            v-for="brand in brandOptionViews"
+            :key="brand.id"
+            :value="brand.value"
+          >
+            {{ brand.name }}
+          </option>
+        </select>
+      </div>
+
+      <div :class="$style.field">
+        <label :class="$style.inputLabel" :for="categoryInputId">
+          Category
+        </label>
+
+        <select
+          :id="categoryInputId"
+          v-model="selectedCategoryId"
+          :class="$style.input"
+          :disabled="isSubmitting"
+          name="categoryId"
+          required
+        >
+          <option value="">
+            Select a category
+          </option>
+
+          <option
+            v-for="category in categoryOptionViews"
+            :key="category.id"
+            :value="category.value"
+          >
+            {{ category.name }}
+          </option>
+        </select>
+      </div>
+
+      <fieldset v-if="showPropertyFields" :class="$style.fieldset">
+        <legend :class="$style.legend">
+          Optional details
+        </legend>
+
+        <p v-if="isCategoryLoading" :class="$style.helperMessage" role="status">
+          Loading category details.
+        </p>
+
+        <div v-else-if="hasCategoryError" :class="$style.errorPanel" role="status">
+          <p :class="$style.helperMessage">
+            Optional category details are unavailable. You can still submit the item.
+          </p>
+
+          <PerdButton variant="secondary" size="small" :disabled="isSubmitting" @click="loadCategoryDetail">
+            Retry
+          </PerdButton>
+        </div>
+
+        <div v-else :class="$style.propertyFields">
+          <div
+            v-for="property in propertyFields"
+            :key="property.id"
+            :class="$style.field"
+          >
+            <label :class="$style.inputLabel" :for="property.inputId">
+              {{ property.name }}
+            </label>
+
+            <input
+              v-if="property.isText"
+              :id="property.inputId"
+              v-model="propertyValues[property.valueKey]"
+              :class="$style.input"
+              :disabled="isSubmitting"
+              :name="property.valueName"
+              autocomplete="off"
+            >
+
+            <input
+              v-else-if="property.isNumber"
+              :id="property.inputId"
+              v-model="propertyValues[property.valueKey]"
+              :class="$style.input"
+              :disabled="isSubmitting"
+              :name="property.valueName"
+              :aria-describedby="property.hintId"
+              inputmode="decimal"
+              :pattern="numberInputPattern"
+              autocomplete="off"
+            >
+
+            <select
+              v-else-if="property.isEnum"
+              :id="property.inputId"
+              v-model="propertyValues[property.valueKey]"
+              :class="$style.input"
+              :disabled="isSubmitting"
+              :name="property.valueName"
+            >
+              <option value="">
+                Not set
+              </option>
+
+              <option
+                v-for="option in property.enumOptions"
+                :key="option.id"
+                :value="option.slug"
+              >
+                {{ option.name }}
+              </option>
+            </select>
+
+            <input
+              v-else-if="property.isBoolean"
+              :id="property.inputId"
+              v-model="propertyValues[property.valueKey]"
+              :class="$style.checkbox"
+              :disabled="isSubmitting"
+              :name="property.valueName"
+              false-value="false"
+              true-value="true"
+              type="checkbox"
+            >
+
+            <p v-if="property.showHint" :id="property.hintId" :class="$style.hint">
+              Use {{ property.unit }}.
+            </p>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+
+    <p v-if="isSubmitErrorVisible" :class="$style.errorMessage" role="alert">
+      {{ submitErrorMessage }}
+    </p>
+
+    <div :class="$style.actions">
+      <PerdButton
+        v-if="showCancelButton"
+        variant="secondary"
+        :disabled="isSubmitting"
+        @click="emitClose"
+      >
+        Cancel
+      </PerdButton>
+
+      <PerdLink v-if="showFullPageLink" :to="fullPageLocation">
+        Add details on full page
+      </PerdLink>
+
+      <PerdButton
+        type="submit"
+        icon="tabler:plus"
+        :loading="isSubmitting"
+        :disabled="isSubmitDisabled"
+      >
+        {{ submitLabel }}
+      </PerdButton>
+    </div>
+  </form>
+</template>
+
+<script lang="ts" setup>
+  import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
+  import { useRequestFetch } from '#imports'
+  import { limits } from '#shared/constants'
+  import type {
+    CatalogEntityDetail,
+    CategoryDetailResponse,
+    CategoryPropertyEnumOption,
+    ItemSubmissionCreateBody,
+    ItemSubmissionCreateResponse,
+    ItemSubmissionPropertyInput
+  } from '~/types/equipment'
+  import PerdButton from '~/components/PerdButton.vue'
+  import PerdHeading from '~/components/PerdHeading.vue'
+  import PerdLink from '~/components/PerdLink.vue'
+
+  interface PropertyFieldView {
+    enumOptions: CategoryPropertyEnumOption[];
+    hintId: string;
+    id: number;
+    inputId: string;
+    isBoolean: boolean;
+    isEnum: boolean;
+    isNumber: boolean;
+    isText: boolean;
+    name: string;
+    showHint: boolean;
+    unit: string;
+    valueKey: string;
+    valueName: string;
+  }
+
+  interface ReferenceOptionView extends CatalogEntityDetail {
+    value: string;
+  }
+
+  interface Props {
+    active?: boolean;
+    formId: string;
+    headingId?: string;
+    initialBrandId?: string;
+    initialCategoryId?: string;
+    initialName?: string;
+    showCancelButton?: boolean;
+    showCloseButton?: boolean;
+    showFullPageLink?: boolean;
+    showHeader?: boolean;
+    showOptionalDetails?: boolean;
+    submitLabel?: string;
+    variant?: 'dialog' | 'page';
+  }
+
+  interface Emits {
+    (event: 'close'): void;
+    (event: 'submitted', response: ItemSubmissionCreateResponse): void;
+    (event: 'submitting', isSubmitting: boolean): void;
+  }
+
+  const {
+    active = true,
+    formId,
+    headingId,
+    initialBrandId = '',
+    initialCategoryId = '',
+    initialName = '',
+    showCancelButton = false,
+    showCloseButton = false,
+    showFullPageLink = false,
+    showHeader = false,
+    showOptionalDetails = false,
+    submitLabel = 'Submit item',
+    variant = 'page'
+  } = defineProps<Props>()
+
+  const emit = defineEmits<Emits>()
+  const $fetch = useRequestFetch()
+  const formRef = useTemplateRef('formRef')
+  const nameInput = useTemplateRef('nameInput')
+
+  const brandOptions = ref<CatalogEntityDetail[]>([])
+  const categoryOptions = ref<CatalogEntityDetail[]>([])
+  const categoryDetail = ref<CategoryDetailResponse | null>(null)
+  const itemName = ref('')
+  const propertyValues = ref<Record<string, string>>({})
+  const referenceStatus = ref<'error' | 'idle' | 'loaded' | 'loading'>('idle')
+  const categoryStatus = ref<'error' | 'idle' | 'loaded' | 'loading'>('idle')
+  const numberInputPattern = String.raw`-?[0-9]+(\.[0-9]+)?`
+  const selectedBrandId = ref('')
+  const selectedCategoryId = ref('')
+  const submitErrorMessage = ref<string | null>(null)
+  const isSubmitting = ref(false)
+  let categoryRequestId = 0
+
+  const nameInputId = computed(() => `${formId}-name`)
+  const brandInputId = computed(() => `${formId}-brand`)
+  const categoryInputId = computed(() => `${formId}-category`)
+  const isReferenceLoading = computed(() => referenceStatus.value === 'loading')
+  const hasReferenceError = computed(() => referenceStatus.value === 'error')
+  const isCategoryLoading = computed(() => categoryStatus.value === 'loading')
+  const hasCategoryError = computed(() => categoryStatus.value === 'error')
+  const isSubmitErrorVisible = computed(() => submitErrorMessage.value !== null)
+
+  function createReferenceOptionView(option: CatalogEntityDetail): ReferenceOptionView {
+    return {
+      id: option.id,
+      name: option.name,
+      slug: option.slug,
+      value: `${option.id}`
+    }
+  }
+
+  const brandOptionViews = computed<ReferenceOptionView[]>(() => brandOptions.value.map(createReferenceOptionView))
+  const categoryOptionViews = computed<ReferenceOptionView[]>(() => categoryOptions.value.map(createReferenceOptionView))
+  const selectedCategory = computed(() => categoryOptionViews.value.find((category) => category.value === selectedCategoryId.value))
+  const showPropertyFields = computed(() => showOptionalDetails && selectedCategoryId.value !== '')
+  const propertyFields = computed<PropertyFieldView[]>(() => {
+    const properties = categoryDetail.value?.properties ?? []
+
+    return properties.map((property) => {
+      const enumOptions = property.enumOptions ?? []
+      const unit = property.unit ?? ''
+
+      return {
+        enumOptions,
+        hintId: `${formId}-property-${property.id}-hint`,
+        id: property.id,
+        inputId: `${formId}-property-${property.id}`,
+        isBoolean: property.dataType === 'boolean',
+        isEnum: property.dataType === 'enum',
+        isNumber: property.dataType === 'number',
+        isText: property.dataType === 'text',
+        name: property.name,
+        showHint: property.dataType === 'number' && unit !== '',
+        unit,
+        valueKey: `${property.id}`,
+        valueName: `property-${property.id}`
+      }
+    })
+  })
+  const isBaseFormIncomplete = computed(() => {
+    const trimmedName = itemName.value.trim()
+
+    return trimmedName === '' || selectedBrandId.value === '' || selectedCategoryId.value === ''
+  })
+  const isSubmitDisabled = computed(() => (
+    isSubmitting.value || isReferenceLoading.value || hasReferenceError.value || isBaseFormIncomplete.value
+  ))
+  const fullPageLocation = computed(() => {
+    const query: Record<string, string> = {}
+    const name = itemName.value.trim()
+
+    if (name !== '') {
+      query.name = name
+    }
+
+    if (selectedBrandId.value !== '') {
+      query.brandId = selectedBrandId.value
+    }
+
+    if (selectedCategoryId.value !== '') {
+      query.categoryId = selectedCategoryId.value
+    }
+
+    return {
+      path: '/gear/new',
+      query
+    }
+  })
+
+  function resetForm() {
+    categoryDetail.value = null
+    categoryStatus.value = 'idle'
+    itemName.value = initialName
+    propertyValues.value = {}
+    selectedBrandId.value = initialBrandId
+    selectedCategoryId.value = initialCategoryId
+    submitErrorMessage.value = null
+  }
+
+  function resetNativeFormState() {
+    formRef.value?.reset()
+  }
+
+  async function loadReferenceData() {
+    if (referenceStatus.value === 'loaded') {
+      return
+    }
+
+    referenceStatus.value = 'loading'
+
+    try {
+      const brandsPromise = $fetch('/api/equipment/brands')
+      const categoriesPromise = $fetch('/api/equipment/categories')
+      const [brandsResponse, categoriesResponse] = await Promise.all([
+        brandsPromise,
+        categoriesPromise
+      ])
+
+      brandOptions.value = brandsResponse
+      categoryOptions.value = categoriesResponse
+      referenceStatus.value = 'loaded'
+    } catch {
+      referenceStatus.value = 'error'
+    }
+  }
+
+  async function loadCategoryDetail() {
+    const category = selectedCategory.value
+
+    if (showOptionalDetails === false || category === undefined) {
+      categoryStatus.value = 'idle'
+
+      return
+    }
+
+    const requestId = categoryRequestId + 1
+    categoryRequestId = requestId
+    categoryStatus.value = 'loading'
+
+    try {
+      const detail = await $fetch<CategoryDetailResponse>(`/api/equipment/categories/${category.slug}`)
+      const isCurrentRequest = requestId === categoryRequestId
+
+      if (isCurrentRequest) {
+        categoryDetail.value = detail
+        categoryStatus.value = 'loaded'
+      }
+    } catch {
+      const isCurrentRequest = requestId === categoryRequestId
+
+      if (isCurrentRequest) {
+        categoryStatus.value = 'error'
+      }
+    }
+  }
+
+  function createSubmittedProperties(): ItemSubmissionPropertyInput[] {
+    const submittedProperties: ItemSubmissionPropertyInput[] = []
+
+    if (showOptionalDetails === false) {
+      return submittedProperties
+    }
+
+    for (const property of propertyFields.value) {
+      const rawValue = propertyValues.value[property.valueKey] ?? ''
+
+      if (rawValue !== '') {
+        const value = property.isBoolean
+          ? rawValue === 'true'
+          : rawValue.trim()
+
+        if (value !== '') {
+          submittedProperties.push({
+            propertyId: property.id,
+            value
+          })
+        }
+      }
+    }
+
+    return submittedProperties
+  }
+
+  function createSubmissionBody(): ItemSubmissionCreateBody {
+    const brandId = Number(selectedBrandId.value)
+    const categoryId = Number(selectedCategoryId.value)
+    const properties = createSubmittedProperties()
+
+    return {
+      brandId,
+      categoryId,
+      name: itemName.value.trim(),
+      properties
+    }
+  }
+
+  function emitClose() {
+    if (isSubmitting.value) {
+      return
+    }
+
+    emit('close')
+  }
+
+  async function handleSubmit() {
+    if (isSubmitDisabled.value) {
+      return
+    }
+
+    submitErrorMessage.value = null
+    isSubmitting.value = true
+    emit('submitting', true)
+
+    try {
+      const body = createSubmissionBody()
+      const response = await $fetch('/api/equipment/item-submissions', {
+        method: 'POST',
+        body
+      })
+
+      emit('submitted', response)
+    } catch {
+      submitErrorMessage.value = 'Could not submit item.'
+    } finally {
+      isSubmitting.value = false
+      emit('submitting', false)
+    }
+  }
+
+  watch(() => active, async (isActive) => {
+    if (isActive === false) {
+      return
+    }
+
+    resetNativeFormState()
+    resetForm()
+    await loadReferenceData()
+
+    if (selectedCategoryId.value !== '' && showOptionalDetails) {
+      await loadCategoryDetail()
+    }
+
+    await nextTick()
+    nameInput.value?.focus()
+  }, {
+    immediate: true
+  })
+
+  watch(selectedCategoryId, async () => {
+    propertyValues.value = {}
+    categoryDetail.value = null
+
+    if (selectedCategoryId.value === '' || active === false || showOptionalDetails === false) {
+      categoryStatus.value = 'idle'
+
+      return
+    }
+
+    await loadCategoryDetail()
+  })
+</script>
+
+<style module>
+  .component {
+    display: grid;
+    row-gap: var(--spacing-20);
+    padding: var(--spacing-24);
+    border: 1px solid var(--color-border-subtle);
+    background:
+      linear-gradient(180deg, var(--color-surface-primary), var(--color-surface-secondary));
+  }
+
+  .component:global(.dialog) {
+    inline-size: min(100vw - var(--spacing-32), 38rem);
+    max-block-size: min(90vh, 48rem);
+    overflow: auto;
+    border-radius: var(--border-radius-24);
+    box-shadow: var(--shadow-large);
+  }
+
+  .component:global(.page) {
+    inline-size: min(100%, 44rem);
+    border-radius: var(--border-radius-16);
+  }
+
+  .header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: var(--spacing-16);
+  }
+
+  .headingBlock {
+    display: grid;
+    gap: var(--spacing-4);
+    min-inline-size: 0;
+  }
+
+  .kicker {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-12);
+    font-weight: var(--font-weight-medium);
+    letter-spacing: var(--letter-spacing-label);
+    text-transform: uppercase;
+  }
+
+  .heading {
+    text-wrap: balance;
+  }
+
+  .description {
+    margin: 0;
+    color: var(--color-text-tertiary);
+    line-height: var(--line-height-body);
+  }
+
+  .closeButton {
+    appearance: none;
+    display: inline-grid;
+    place-items: center;
+    inline-size: 2.25rem;
+    block-size: 2.25rem;
+    padding: 0;
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--border-radius-12);
+    background: var(--color-surface-primary);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 1rem;
+    transition:
+      background-color var(--transition-duration-fast) var(--transition-easing-standard),
+      border-color var(--transition-duration-fast) var(--transition-easing-standard),
+      box-shadow var(--transition-duration-fast) var(--transition-easing-standard),
+      color var(--transition-duration-fast) var(--transition-easing-standard);
+
+    &:hover {
+      border-color: var(--color-border-strong);
+      background: var(--color-surface-secondary);
+      color: var(--color-text-primary);
+    }
+
+    &:focus-visible {
+      border-color: var(--color-border-strong);
+      color: var(--color-text-primary);
+      box-shadow: var(--shadow-focus);
+    }
+
+    &:disabled {
+      border-color: transparent;
+      background: var(--color-surface-secondary);
+      color: var(--color-text-muted);
+      cursor: not-allowed;
+    }
+  }
+
+  .fields {
+    display: grid;
+    gap: var(--spacing-16);
+  }
+
+  .field {
+    display: grid;
+    gap: var(--spacing-8);
+  }
+
+  .inputLabel {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-12);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .input {
+    box-sizing: border-box;
+    inline-size: 100%;
+    min-block-size: 3rem;
+    padding-inline: var(--spacing-12);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--border-radius-12);
+    background: var(--color-background-elevated);
+    color: var(--color-text-primary);
+    font: inherit;
+    transition:
+      border-color var(--transition-duration-fast) var(--transition-easing-standard),
+      box-shadow var(--transition-duration-fast) var(--transition-easing-standard);
+
+    &:focus-visible {
+      border-color: var(--color-accent-primary);
+      box-shadow: var(--shadow-focus);
+      outline: 0;
+    }
+
+    &:user-invalid {
+      border-color: var(--color-danger-primary);
+      box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-danger-primary) 24%, transparent);
+    }
+
+    &:disabled {
+      color: var(--color-text-muted);
+      cursor: not-allowed;
+    }
+  }
+
+  .checkbox {
+    inline-size: 1.25rem;
+    block-size: 1.25rem;
+    margin: 0;
+    accent-color: var(--color-accent-primary);
+  }
+
+  .fieldset {
+    display: grid;
+    gap: var(--spacing-16);
+    min-inline-size: 0;
+    padding: var(--spacing-16);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--border-radius-16);
+    background: var(--color-surface-secondary);
+  }
+
+  .legend {
+    padding-inline: var(--spacing-4);
+    color: var(--color-text-secondary);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .propertyFields {
+    display: grid;
+    gap: var(--spacing-16);
+  }
+
+  .hint {
+    margin: 0;
+    color: var(--color-text-tertiary);
+    font-size: var(--font-size-14);
+  }
+
+  .helperMessage {
+    margin: 0;
+    color: var(--color-text-tertiary);
+  }
+
+  .errorPanel {
+    display: grid;
+    gap: var(--spacing-12);
+    justify-items: start;
+  }
+
+  .errorMessage {
+    margin: 0;
+    color: var(--color-danger-primary);
+    overflow-wrap: anywhere;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: var(--spacing-12);
+    align-items: center;
+  }
+</style>

--- a/app/components/packing/PackingListCreateDialog.vue
+++ b/app/components/packing/PackingListCreateDialog.vue
@@ -3,6 +3,7 @@
     v-model="isOpened"
     :close-disabled="loading"
     aria-labelledby="new-pack-dialog-title"
+    overlay-close-disabled
   >
     <form :class="$style.component" @submit.prevent="handleSubmit">
       <div :class="$style.header">

--- a/app/pages/catalog/index.vue
+++ b/app/pages/catalog/index.vue
@@ -1,5 +1,11 @@
 <template>
   <PageContent page-title="Catalog">
+    <template #actions>
+      <PerdButton icon="tabler:plus" @click="openSubmissionDialog">
+        Add gear
+      </PerdButton>
+    </template>
+
     <div :class="$style.component">
       <PageLoadingState
         v-if="isInitialLoading"
@@ -17,6 +23,14 @@
       </PagePlaceholder>
 
       <div v-else :class="$style.results">
+        <p v-if="submittedItem" :class="$style.successMessage" role="status">
+          Submitted
+          <PerdLink :to="submittedItemPath">
+            {{ submittedItem.name }}
+          </PerdLink>
+          for review. It is in your inventory now.
+        </p>
+
         <PageSummaryHeader label="Catalog" :value="itemsSummaryText" />
 
         <PagePlaceholder v-if="isEmpty" emoji="🧺" title="No items yet." />
@@ -40,19 +54,27 @@
         />
       </div>
     </div>
+
+    <EquipmentItemSubmissionDialog
+      v-model="isSubmissionDialogVisible"
+      @submitted="handleSubmissionSubmitted"
+    />
   </PageContent>
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
+  import { computed, ref } from 'vue'
   import { definePageMeta, navigateTo, useFetch, useRoute } from '#imports'
+  import type { ItemSubmissionCreateResponse, SubmittedCatalogItem } from '~/types/equipment'
   import { buildCatalogRouteQuery, getCatalogItemsApiQuery, getCatalogRouteState } from '~/utils/catalog'
   import PageLoadingState from '~/components/PageLoadingState.vue'
   import PagePlaceholder from '~/components/PagePlaceholder.vue'
   import PageSummaryHeader from '~/components/PageSummaryHeader.vue'
   import PerdButton from '~/components/PerdButton.vue'
+  import PerdLink from '~/components/PerdLink.vue'
   import CatalogPagination from '~/components/catalog/CatalogPagination.vue'
   import CatalogResultsPanel from '~/components/catalog/CatalogResultsPanel.vue'
+  import EquipmentItemSubmissionDialog from '~/components/equipment/EquipmentItemSubmissionDialog.vue'
   import PageContent from '~/components/layout/PageContent.vue'
 
   definePageMeta({
@@ -60,6 +82,8 @@
   })
 
   const route = useRoute()
+  const isSubmissionDialogVisible = ref(false)
+  const submittedItem = ref<SubmittedCatalogItem | null>(null)
   const routeState = computed(() => getCatalogRouteState(route.query))
   const itemsApiQuery = computed(() => getCatalogItemsApiQuery(route.query))
 
@@ -104,6 +128,7 @@
   }))
   const isPreviousPageDisabled = computed(() => canGoPrevious.value === false || isRefreshing.value)
   const isNextPageDisabled = computed(() => canGoNext.value === false || isRefreshing.value)
+  const submittedItemPath = computed(() => submittedItem.value === null ? '' : `/catalog/${submittedItem.value.id}`)
 
   async function handlePageChange(page: number) {
     const currentPage = routeState.value.page
@@ -136,6 +161,14 @@
   async function handleGoToNextPage() {
     await handlePageChange(itemsResponse.value.page + 1)
   }
+
+  function openSubmissionDialog() {
+    isSubmissionDialogVisible.value = true
+  }
+
+  function handleSubmissionSubmitted(response: ItemSubmissionCreateResponse) {
+    submittedItem.value = response.item
+  }
 </script>
 
 <style module>
@@ -146,6 +179,15 @@
   .results {
     display: grid;
     gap: var(--spacing-24);
+  }
+
+  .successMessage {
+    margin: 0;
+    padding: var(--spacing-12);
+    border: 1px solid var(--color-success-subtle);
+    border-radius: var(--border-radius-12);
+    background: var(--color-success-subtle);
+    color: var(--color-text-primary);
   }
 
 </style>

--- a/app/pages/gear/new.vue
+++ b/app/pages/gear/new.vue
@@ -1,0 +1,88 @@
+<template>
+  <PageContent page-title="Add gear">
+    <template #actions>
+      <PerdLink to="/inventory">
+        View inventory
+      </PerdLink>
+
+      <PerdLink to="/catalog">
+        Browse catalog
+      </PerdLink>
+    </template>
+
+    <div :class="$style.component">
+      <p v-if="submittedItem" :class="$style.successMessage" role="status">
+        Submitted
+        <PerdLink :to="submittedItemPath">
+          {{ submittedItem.name }}
+        </PerdLink>
+        for review. It is in your inventory now.
+      </p>
+
+      <EquipmentItemSubmissionForm
+        form-id="gear-new-submission"
+        :initial-brand-id="initialBrandId"
+        :initial-category-id="initialCategoryId"
+        :initial-name="initialName"
+        show-optional-details
+        submit-label="Submit item"
+        variant="page"
+        @submitted="handleSubmitted"
+      />
+    </div>
+  </PageContent>
+</template>
+
+<script lang="ts" setup>
+  import { computed, ref } from 'vue'
+  import { definePageMeta, useRoute } from '#imports'
+  import type { ItemSubmissionCreateResponse, SubmittedCatalogItem } from '~/types/equipment'
+  import PerdLink from '~/components/PerdLink.vue'
+  import EquipmentItemSubmissionForm from '~/components/equipment/EquipmentItemSubmissionForm.vue'
+  import PageContent from '~/components/layout/PageContent.vue'
+
+  definePageMeta({
+    layout: 'page'
+  })
+
+  const route = useRoute()
+  const submittedItem = ref<SubmittedCatalogItem | null>(null)
+
+  function getQueryValue(value: unknown) {
+    if (typeof value === 'string') {
+      return value
+    }
+
+    if (Array.isArray(value) && typeof value[0] === 'string') {
+      return value[0]
+    }
+
+    return ''
+  }
+
+  const initialName = computed(() => getQueryValue(route.query.name))
+  const initialBrandId = computed(() => getQueryValue(route.query.brandId))
+  const initialCategoryId = computed(() => getQueryValue(route.query.categoryId))
+  const submittedItemPath = computed(() => submittedItem.value === null ? '' : `/catalog/${submittedItem.value.id}`)
+
+  function handleSubmitted(response: ItemSubmissionCreateResponse) {
+    submittedItem.value = response.item
+  }
+</script>
+
+<style module>
+  .component {
+    display: grid;
+    gap: var(--spacing-24);
+  }
+
+  .successMessage {
+    margin: 0;
+    inline-size: min(100%, 44rem);
+    padding: var(--spacing-12);
+    border: 1px solid var(--color-success-subtle);
+    border-radius: var(--border-radius-12);
+    background: var(--color-success-subtle);
+    color: var(--color-text-primary);
+  }
+</style>

--- a/app/pages/inventory.vue
+++ b/app/pages/inventory.vue
@@ -1,6 +1,10 @@
 <template>
   <PageContent page-title="Inventory">
     <template #actions>
+      <PerdButton icon="tabler:plus" @click="openSubmissionDialog">
+        Add gear
+      </PerdButton>
+
       <PerdLink to="/catalog">
         Browse catalog
       </PerdLink>
@@ -25,6 +29,10 @@
       <PagePlaceholder v-else-if="isEmpty" emoji="🧺" title="No saved gear yet." />
 
       <div v-else :class="$style.list">
+        <p v-if="submittedItemName" :class="$style.successMessage" role="status">
+          Submitted {{ submittedItemName }} for review.
+        </p>
+
         <PageSummaryHeader label="My gear" :value="inventorySummaryText" />
 
         <p v-if="removeErrorMessage" :class="$style.errorMessage" role="status">
@@ -39,18 +47,24 @@
         />
       </div>
     </div>
+
+    <EquipmentItemSubmissionDialog
+      v-model="isSubmissionDialogVisible"
+      @submitted="handleSubmissionSubmitted"
+    />
   </PageContent>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref } from 'vue'
-  import { $fetch } from 'ofetch'
-  import { definePageMeta, useFetch } from '#imports'
+  import { definePageMeta, useFetch, useRequestFetch } from '#imports'
+  import type { ItemSubmissionCreateResponse } from '~/types/equipment'
   import PageLoadingState from '~/components/PageLoadingState.vue'
   import PagePlaceholder from '~/components/PagePlaceholder.vue'
   import PageSummaryHeader from '~/components/PageSummaryHeader.vue'
   import PerdButton from '~/components/PerdButton.vue'
   import PerdLink from '~/components/PerdLink.vue'
+  import EquipmentItemSubmissionDialog from '~/components/equipment/EquipmentItemSubmissionDialog.vue'
   import InventoryItemCard from '~/components/inventory/InventoryItemCard.vue'
   import PageContent from '~/components/layout/PageContent.vue'
 
@@ -60,6 +74,9 @@
 
   const removeErrorMessage = ref<string | null>(null)
   const removingInventoryId = ref<string | null>(null)
+  const isSubmissionDialogVisible = ref(false)
+  const submittedItemName = ref<string | null>(null)
+  const $fetch = useRequestFetch()
   const inventoryDateFormatter = new Intl.DateTimeFormat('en', {
     dateStyle: 'medium'
   })
@@ -115,6 +132,18 @@
     }
   }
 
+  function openSubmissionDialog() {
+    isSubmissionDialogVisible.value = true
+  }
+
+  function handleSubmissionSubmitted(response: ItemSubmissionCreateResponse) {
+    submittedItemName.value = response.item.name
+    inventoryResponse.value = [
+      response.inventory,
+      ...inventoryResponse.value.filter((inventoryRow) => inventoryRow.id !== response.inventory.id)
+    ]
+  }
+
   const inventoryItems = computed(() => inventoryResponse.value.map((inventoryRow) => {
     return {
       catalogPath: `/catalog/${inventoryRow.item.id}`,
@@ -136,6 +165,15 @@
   .errorMessage {
     margin: 0;
     color: var(--color-danger-primary);
+  }
+
+  .successMessage {
+    margin: 0;
+    padding: var(--spacing-12);
+    border: 1px solid var(--color-success-subtle);
+    border-radius: var(--border-radius-12);
+    background: var(--color-success-subtle);
+    color: var(--color-text-primary);
   }
 
   .list {

--- a/app/types/equipment.ts
+++ b/app/types/equipment.ts
@@ -7,6 +7,25 @@ interface CatalogEntityDetail extends CatalogEntitySummary {
   id: number;
 }
 
+interface CategoryPropertyEnumOption {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface CategoryPropertyDetail {
+  dataType: string;
+  enumOptions?: CategoryPropertyEnumOption[];
+  id: number;
+  name: string;
+  slug: string;
+  unit: string | null;
+}
+
+interface CategoryDetailResponse extends CatalogEntityDetail {
+  properties: CategoryPropertyDetail[];
+}
+
 interface CatalogListItem {
   brand: CatalogEntitySummary;
   category: CatalogEntitySummary;
@@ -51,6 +70,28 @@ interface ItemDisplayProperty extends ItemProperty {
   displayValue: string;
 }
 
+interface ItemSubmissionPropertyInput {
+  propertyId: number;
+  value: boolean | string;
+}
+
+interface ItemSubmissionCreateBody {
+  brandId: number;
+  categoryId: number;
+  name: string;
+  properties: ItemSubmissionPropertyInput[];
+}
+
+interface SubmittedCatalogItem {
+  brand: CatalogEntitySummary;
+  category: CatalogEntitySummary;
+  createdAt: string;
+  id: string;
+  name: string;
+  properties: ItemProperty[];
+  status: string;
+}
+
 interface InventoryItem {
   brand: CatalogEntitySummary;
   category: CatalogEntitySummary;
@@ -74,7 +115,15 @@ interface InventoryRecordView {
   item: InventoryItem;
 }
 
+interface ItemSubmissionCreateResponse {
+  inventory: InventoryRecord;
+  item: SubmittedCatalogItem;
+}
+
 export type {
+  CategoryDetailResponse,
+  CategoryPropertyDetail,
+  CategoryPropertyEnumOption,
   CatalogEntityDetail,
   CatalogEntitySummary,
   CatalogItemsResponse,
@@ -83,7 +132,11 @@ export type {
   InventoryItem,
   InventoryRecord,
   InventoryRecordView,
+  ItemSubmissionCreateBody,
+  ItemSubmissionCreateResponse,
+  ItemSubmissionPropertyInput,
   ItemDetailResponse,
   ItemDisplayProperty,
-  ItemProperty
+  ItemProperty,
+  SubmittedCatalogItem
 }

--- a/server/api/equipment/categories/[slug].get.ts
+++ b/server/api/equipment/categories/[slug].get.ts
@@ -1,8 +1,11 @@
-import { createError, defineEventHandler, getValidatedRouterParams } from 'h3'
+import { createError, defineEventHandler, getRouterParams } from 'h3'
 import { validateCategoryDetailParams } from '#server/utils/validation/schemas'
 
 export default defineEventHandler(async (event) => {
-  const { slug } = await getValidatedRouterParams(event, validateCategoryDetailParams)
+  const params = getRouterParams(event)
+  const { slug } = validateCategoryDetailParams({
+    slug: params.slug ?? params.id
+  })
 
   const category = await event.context.dbHttp.query.equipmentCategories.findFirst({
     columns: {

--- a/server/api/equipment/categories/__tests__/reads.test.ts
+++ b/server/api/equipment/categories/__tests__/reads.test.ts
@@ -1,28 +1,6 @@
-import * as h3 from 'h3'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import categoryDetailHandler from '#server/api/equipment/categories/[slug].get'
 import { createTestEvent } from '~~/test-utils/create-test-event'
-
-const {
-  getValidatedRouterParamsMock
-} = vi.hoisted(() => {
-  return {
-    getValidatedRouterParamsMock: vi.fn<typeof h3.getValidatedRouterParams>()
-  }
-})
-
-// @ts-expect-error -- Vitest's import-based module mock typing rejects this partial h3 mock.
-vi.mock(import('h3'), async () => {
-  const actual = await vi.importActual<typeof h3>('h3')
-
-  return {
-    ...actual,
-
-    async getValidatedRouterParams(...args: Parameters<typeof h3.getValidatedRouterParams>) {
-      return getValidatedRouterParamsMock(...args)
-    }
-  }
-})
 
 interface CategoryPropertyEnumOption {
   id: number;
@@ -62,19 +40,17 @@ function createDetailDb(category?: CategoryDetail) {
   }
 }
 
+function createDetailEvent(dbHttp: unknown, params?: Record<string, string>) {
+  const event = createTestEvent(dbHttp)
+
+  event.context.params = params ?? {
+    slug: 'sleeping-bags'
+  }
+
+  return event
+}
+
 describe('get /api/equipment/categories/[slug]', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-
-    getValidatedRouterParamsMock.mockResolvedValue({
-      slug: 'sleeping-bags'
-    })
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
   it('should return category detail and keep enum options only for enum properties', async () => {
     const category = {
       id: 1,
@@ -105,7 +81,7 @@ describe('get /api/equipment/categories/[slug]', () => {
     }
 
     const { dbHttp, findFirstMock } = createDetailDb(category)
-    const event = createTestEvent(dbHttp)
+    const event = createDetailEvent(dbHttp)
     const result = await categoryDetailHandler(event)
 
     expect(result).toStrictEqual({
@@ -137,21 +113,47 @@ describe('get /api/equipment/categories/[slug]', () => {
     expect(findFirstMock).toHaveBeenCalledTimes(1)
   })
 
-  it('should return 400 when route params validation fails', async () => {
-    const routeError = h3.createError({ status: 400 })
-    const { dbHttp } = createDetailDb()
-    const event = createTestEvent(dbHttp)
+  it('should read the slug from id when mixed dynamic category routes share a path', async () => {
+    const category = {
+      id: 1,
+      name: 'Sleeping Pads',
+      slug: 'sleeping-pads',
 
-    getValidatedRouterParamsMock.mockRejectedValue(routeError)
+      properties: []
+    }
 
-    await expect(categoryDetailHandler(event)).rejects.toMatchObject({
-      statusCode: 400
+    const { dbHttp, findFirstMock } = createDetailDb(category)
+    const event = createDetailEvent(dbHttp, {
+      id: 'sleeping-pads'
     })
+    const result = await categoryDetailHandler(event)
+
+    expect(result).toStrictEqual({
+      id: 1,
+      name: 'Sleeping Pads',
+      properties: [],
+      slug: 'sleeping-pads'
+    })
+
+    expect(findFirstMock).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        slug: 'sleeping-pads'
+      }
+    }))
+  })
+
+  it('should return 400 when route params validation fails', async () => {
+    const { dbHttp } = createDetailDb()
+    const event = createDetailEvent(dbHttp, {
+      slug: 'bad slug'
+    })
+
+    await expect(categoryDetailHandler(event)).rejects.toThrow(/Invalid/u)
   })
 
   it('should return 404 when category slug does not exist', async () => {
     const { dbHttp } = createDetailDb()
-    const event = createTestEvent(dbHttp)
+    const event = createDetailEvent(dbHttp)
 
     await expect(categoryDetailHandler(event)).rejects.toMatchObject({
       statusCode: 404

--- a/server/api/equipment/item-submissions/[id].patch.ts
+++ b/server/api/equipment/item-submissions/[id].patch.ts
@@ -1,0 +1,143 @@
+import { and, eq } from 'drizzle-orm'
+import { createError, defineEventHandler, getValidatedRouterParams, isError, readValidatedBody } from 'h3'
+
+import {
+  brands,
+  contributions,
+  equipmentCategories,
+  equipmentItems
+} from '#server/database/schema'
+
+import { validateAdminUser } from '#server/utils/admin'
+import { createWebSocketClientFromEvent } from '#server/utils/config'
+
+import {
+  validateItemDetailParams,
+  validateItemSubmissionModerationBody
+} from '#server/utils/validation/schemas'
+
+interface CatalogEntitySummary {
+  name: string;
+  slug: string;
+}
+
+interface ItemSubmissionSummary {
+  brand: CatalogEntitySummary;
+  category: CatalogEntitySummary;
+  createdAt: Date | string;
+  createdBy: string | null;
+  id: string;
+  name: string;
+  status: string;
+}
+
+export default defineEventHandler(async (event) : Promise<ItemSubmissionSummary> => {
+  const userId = await validateAdminUser(event)
+  const { id } = await getValidatedRouterParams(event, validateItemDetailParams)
+  const { status } = await readValidatedBody(event, validateItemSubmissionModerationBody)
+  const dbWebsocket = createWebSocketClientFromEvent(event)
+
+  try {
+    return await dbWebsocket.transaction(async (transaction) => {
+      const [currentItem] = await transaction
+        .select({
+          brandName: brands.name,
+          brandSlug: brands.slug,
+          categoryName: equipmentCategories.name,
+          categorySlug: equipmentCategories.slug,
+          createdAt: equipmentItems.createdAt,
+          createdBy: equipmentItems.createdBy,
+          id: equipmentItems.id,
+          name: equipmentItems.name,
+          status: equipmentItems.status
+        })
+        .from(equipmentItems)
+        .innerJoin(brands, eq(equipmentItems.brandId, brands.id))
+        .innerJoin(equipmentCategories, eq(equipmentItems.categoryId, equipmentCategories.id))
+        .where(
+          eq(equipmentItems.id, id)
+        )
+        .limit(1)
+
+      if (currentItem === undefined) {
+        throw createError({ status: 404 })
+      }
+
+      if (currentItem.status !== 'pending') {
+        throw createError({
+          status: 409,
+          message: 'Only pending item submissions can be moderated'
+        })
+      }
+
+      const [updatedItem] = await transaction
+        .update(equipmentItems)
+        .set({
+          status
+        })
+        .where(
+          and(
+            eq(equipmentItems.id, id),
+            eq(equipmentItems.status, 'pending')
+          )
+        )
+        .returning({
+          status: equipmentItems.status
+        })
+
+      if (updatedItem === undefined) {
+        throw createError({
+          status: 409,
+          message: 'Only pending item submissions can be moderated'
+        })
+      }
+
+      const action = status === 'approved'
+        ? 'approve_equipment_item'
+        : 'reject_equipment_item'
+
+      await transaction
+        .insert(contributions)
+        .values({
+          action,
+
+          metadata: {
+            previousStatus: currentItem.status,
+            status: updatedItem.status
+          },
+
+          targetId: currentItem.id,
+          userId
+        })
+
+      return {
+        brand: {
+          name: currentItem.brandName,
+          slug: currentItem.brandSlug
+        },
+
+        category: {
+          name: currentItem.categoryName,
+          slug: currentItem.categorySlug
+        },
+
+        createdAt: currentItem.createdAt,
+        createdBy: currentItem.createdBy,
+        id: currentItem.id,
+        name: currentItem.name,
+        status: updatedItem.status
+      }
+    })
+  } catch (error) {
+    if (isError(error)) {
+      throw error
+    }
+
+    throw createError({
+      status: 500,
+      message: 'Failed to moderate item submission'
+    })
+  } finally {
+    await dbWebsocket.$client.end()
+  }
+})

--- a/server/api/equipment/item-submissions/__tests__/handlers.test.ts
+++ b/server/api/equipment/item-submissions/__tests__/handlers.test.ts
@@ -1,0 +1,909 @@
+import * as h3 from 'h3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import moderateSubmissionHandler from '#server/api/equipment/item-submissions/[id].patch'
+import listSubmissionsHandler from '#server/api/equipment/item-submissions/index.get'
+import createSubmissionHandler from '#server/api/equipment/item-submissions/index.post'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+interface MockWriteTransaction {
+  insert: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+}
+
+interface MockWriteDb {
+  $client: {
+    end: ReturnType<typeof vi.fn>;
+  };
+  transaction: ReturnType<typeof vi.fn>;
+}
+
+interface SelectOperation {
+  rows: unknown;
+  type: 'limit' | 'where';
+}
+
+interface InsertOperation {
+  result?: unknown;
+  type: 'returning' | 'values';
+}
+
+const userId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
+const itemId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+const inventoryId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d8'
+
+const {
+  createWebSocketClientMock,
+  getValidatedRouterParamsMock,
+  readValidatedBodyMock,
+  setResponseStatusMock,
+  validateAdminUserMock,
+  validateSessionUserMock
+} = vi.hoisted(() => {
+  return {
+    createWebSocketClientMock: vi.fn<() => MockWriteDb>(() => {
+      throw new Error('createWebSocketClient mock is not configured')
+    }),
+    getValidatedRouterParamsMock: vi.fn<typeof h3.getValidatedRouterParams>(),
+    readValidatedBodyMock: vi.fn<typeof h3.readValidatedBody>(),
+    setResponseStatusMock: vi.fn<typeof h3.setResponseStatus>(),
+    validateAdminUserMock: vi.fn<() => Promise<string>>(),
+    validateSessionUserMock: vi.fn<() => Promise<string>>()
+  }
+})
+
+// @ts-expect-error -- Vitest's import-based module mock typing rejects this partial h3 mock.
+vi.mock(import('h3'), async () => {
+  const actual = await vi.importActual<typeof h3>('h3')
+
+  return {
+    ...actual,
+
+    async getValidatedRouterParams(...args: Parameters<typeof h3.getValidatedRouterParams>) {
+      return getValidatedRouterParamsMock(...args)
+    },
+
+    async readValidatedBody(...args: Parameters<typeof h3.readValidatedBody>) {
+      return readValidatedBodyMock(...args)
+    },
+
+    setResponseStatus(...args: Parameters<typeof h3.setResponseStatus>) {
+      setResponseStatusMock(...args)
+    }
+  }
+})
+
+vi.mock(import('#server/utils/admin'), () => {
+  return {
+    validateAdminUser: validateAdminUserMock
+  }
+})
+
+// @ts-expect-error -- Vitest's import-based module mock typing rejects this partial config mock.
+vi.mock(import('#server/utils/config'), () => {
+  return {
+    createWebSocketClientFromEvent: createWebSocketClientMock
+  }
+})
+
+vi.mock(import('#server/utils/session'), () => {
+  return {
+    validateSessionUser: validateSessionUserMock
+  }
+})
+
+function createSelectMock(operations: SelectOperation[]) {
+  const whereMock = vi.fn(() => {
+    const operation = operations.shift()
+
+    if (operation === undefined) {
+      throw new Error('No select operation configured')
+    }
+
+    if (operation.type === 'limit') {
+      return {
+        limit: vi.fn(() => operation.rows)
+      }
+    }
+
+    return operation.rows
+  })
+
+  const fromMock = vi.fn(() => {
+    return {
+      where: whereMock
+    }
+  })
+
+  const selectMock = vi.fn(() => {
+    return {
+      from: fromMock
+    }
+  })
+
+  return {
+    selectMock
+  }
+}
+
+function createJoinedSelectMock(rows: unknown) {
+  const limitMock = vi.fn(() => rows)
+  const whereMock = vi.fn(() => {
+    return {
+      limit: limitMock
+    }
+  })
+  const secondJoinMock = vi.fn(() => {
+    return {
+      where: whereMock
+    }
+  })
+  const firstJoinMock = vi.fn(() => {
+    return {
+      innerJoin: secondJoinMock
+    }
+  })
+  const fromMock = vi.fn(() => {
+    return {
+      innerJoin: firstJoinMock
+    }
+  })
+  const selectMock = vi.fn(() => {
+    return {
+      from: fromMock
+    }
+  })
+
+  return {
+    selectMock
+  }
+}
+
+function createInsertMock(operations: InsertOperation[]) {
+  const valuesMocks: ReturnType<typeof vi.fn>[] = []
+
+  const insertMock = vi.fn(() => {
+    const operation = operations.shift()
+
+    if (operation === undefined) {
+      throw new Error('No insert operation configured')
+    }
+
+    const valuesMock = vi.fn(() => {
+      if (operation.type === 'returning') {
+        return {
+          returning: vi.fn(() => operation.result)
+        }
+      }
+
+    })
+
+    valuesMocks.push(valuesMock)
+
+    return {
+      values: valuesMock
+    }
+  })
+
+  return {
+    insertMock,
+    valuesMocks
+  }
+}
+
+function createUpdateMock(result: unknown) {
+  const returningMock = vi.fn(() => result)
+  const whereMock = vi.fn(() => {
+    return {
+      returning: returningMock
+    }
+  })
+  const setMock = vi.fn(() => {
+    return {
+      where: whereMock
+    }
+  })
+  const updateMock = vi.fn(() => {
+    return {
+      set: setMock
+    }
+  })
+
+  return {
+    setMock,
+    updateMock
+  }
+}
+
+function createWriteDb(transaction: MockWriteTransaction) {
+  const transactionMock = vi.fn(
+    async (executeTransaction: (db: MockWriteTransaction) => Promise<unknown>) => executeTransaction(transaction)
+  )
+  const endMock = vi.fn(async () => {
+    await Promise.resolve()
+  })
+
+  return {
+    $client: {
+      end: endMock
+    },
+    transaction: transactionMock
+  }
+}
+
+function createAdminListDb(rows: unknown[]) {
+  const orderByMock = vi.fn(() => rows)
+  const whereMock = vi.fn(() => {
+    return {
+      orderBy: orderByMock
+    }
+  })
+  const secondJoinMock = vi.fn(() => {
+    return {
+      where: whereMock
+    }
+  })
+  const firstJoinMock = vi.fn(() => {
+    return {
+      innerJoin: secondJoinMock
+    }
+  })
+  const fromMock = vi.fn(() => {
+    return {
+      innerJoin: firstJoinMock
+    }
+  })
+  const selectMock = vi.fn(() => {
+    return {
+      from: fromMock
+    }
+  })
+
+  return {
+    select: selectMock
+  }
+}
+
+describe('item submission handlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    getValidatedRouterParamsMock.mockResolvedValue({
+      id: itemId
+    })
+
+    readValidatedBodyMock.mockResolvedValue({
+      brandId: 1,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+
+      properties: [{
+        propertyId: 10,
+        value: '83'
+      }, {
+        propertyId: 11,
+        value: false
+      }, {
+        propertyId: 12,
+        value: 'canister'
+      }]
+    })
+
+    validateAdminUserMock.mockResolvedValue(userId)
+    validateSessionUserMock.mockResolvedValue(userId)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('post /api/equipment/item-submissions', () => {
+    it('should create a pending item, property rows, inventory row, and contribution', async () => {
+      const { selectMock } = createSelectMock([{
+        rows: [{
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        }],
+        type: 'limit'
+      }, {
+        rows: [{
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }],
+        type: 'limit'
+      }, {
+        rows: [],
+        type: 'limit'
+      }, {
+        rows: [{
+          dataType: 'number',
+          id: 10,
+          name: 'Weight',
+          slug: 'weight',
+          unit: 'g'
+        }, {
+          dataType: 'boolean',
+          id: 11,
+          name: 'Piezo',
+          slug: 'piezo',
+          unit: null
+        }, {
+          dataType: 'enum',
+          id: 12,
+          name: 'Fuel',
+          slug: 'fuel',
+          unit: null
+        }],
+        type: 'where'
+      }, {
+        rows: [{
+          propertyId: 12,
+          slug: 'canister'
+        }],
+        type: 'where'
+      }])
+
+      const { insertMock, valuesMocks } = createInsertMock([{
+        result: [{
+          createdAt: '2026-04-01T00:00:00.000Z',
+          id: itemId,
+          name: 'PocketRocket Deluxe',
+          status: 'pending'
+        }],
+        type: 'returning'
+      }, {
+        type: 'values'
+      }, {
+        result: [{
+          createdAt: '2026-04-01T00:00:00.000Z',
+          id: inventoryId
+        }],
+        type: 'returning'
+      }, {
+        type: 'values'
+      }])
+
+      const dbWrite = createWriteDb({
+        insert: insertMock,
+        select: selectMock,
+        update: vi.fn()
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+      const result = await createSubmissionHandler(event)
+
+      expect(result).toStrictEqual({
+        inventory: {
+          createdAt: '2026-04-01T00:00:00.000Z',
+          id: inventoryId,
+
+          item: {
+            id: itemId,
+            name: 'PocketRocket Deluxe',
+
+            brand: {
+              name: 'MSR',
+              slug: 'msr'
+            },
+
+            category: {
+              name: 'Stoves',
+              slug: 'stoves'
+            }
+          }
+        },
+
+        item: {
+          createdAt: '2026-04-01T00:00:00.000Z',
+          id: itemId,
+          name: 'PocketRocket Deluxe',
+
+          brand: {
+            name: 'MSR',
+            slug: 'msr'
+          },
+
+          category: {
+            name: 'Stoves',
+            slug: 'stoves'
+          },
+
+          properties: [{
+            dataType: 'number',
+            name: 'Weight',
+            slug: 'weight',
+            unit: 'g',
+            value: '83'
+          }, {
+            dataType: 'boolean',
+            name: 'Piezo',
+            slug: 'piezo',
+            unit: null,
+            value: 'false'
+          }, {
+            dataType: 'enum',
+            name: 'Fuel',
+            slug: 'fuel',
+            unit: null,
+            value: 'canister'
+          }],
+
+          status: 'pending'
+        }
+      })
+
+      expect(setResponseStatusMock).toHaveBeenCalledWith(event, 201)
+      expect(valuesMocks[1]).toHaveBeenCalledWith([{
+        itemId,
+        propertyId: 10,
+        valueBoolean: null,
+        valueNumber: '83',
+        valueText: null
+      }, {
+        itemId,
+        propertyId: 11,
+        valueBoolean: false,
+        valueNumber: null,
+        valueText: null
+      }, {
+        itemId,
+        propertyId: 12,
+        valueBoolean: null,
+        valueNumber: null,
+        valueText: 'canister'
+      }])
+      expect(valuesMocks[3]).toHaveBeenCalledWith({
+        action: 'submit_equipment_item',
+
+        metadata: {
+          brandId: 1,
+          categoryId: 2,
+          name: 'PocketRocket Deluxe',
+          propertyCount: 3,
+          status: 'pending'
+        },
+
+        targetId: itemId,
+        userId
+      })
+      expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return 401 when user is unauthenticated', async () => {
+      const authError = h3.createError({ status: 401 })
+      const event = createTestEvent({})
+
+      validateSessionUserMock.mockRejectedValue(authError)
+
+      await expect(createSubmissionHandler(event)).rejects.toMatchObject({
+        statusCode: 401
+      })
+
+      expect(createWebSocketClientMock).not.toHaveBeenCalled()
+    })
+
+    it('should return 404 when brand is missing', async () => {
+      const { selectMock } = createSelectMock([{
+        rows: [],
+        type: 'limit'
+      }])
+      const dbWrite = createWriteDb({
+        insert: vi.fn(),
+        select: selectMock,
+        update: vi.fn()
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+
+      await expect(createSubmissionHandler(event)).rejects.toMatchObject({
+        statusCode: 404
+      })
+    })
+
+    it('should return 409 when a non-rejected duplicate exists', async () => {
+      const { selectMock } = createSelectMock([{
+        rows: [{
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        }],
+        type: 'limit'
+      }, {
+        rows: [{
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }],
+        type: 'limit'
+      }, {
+        rows: [{
+          id: itemId
+        }],
+        type: 'limit'
+      }])
+      const dbWrite = createWriteDb({
+        insert: vi.fn(),
+        select: selectMock,
+        update: vi.fn()
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+
+      await expect(createSubmissionHandler(event)).rejects.toMatchObject({
+        statusCode: 409
+      })
+    })
+
+    it('should return 400 when a submitted property is outside the category', async () => {
+      readValidatedBodyMock.mockResolvedValue({
+        brandId: 1,
+        categoryId: 2,
+        name: 'PocketRocket Deluxe',
+
+        properties: [{
+          propertyId: 99,
+          value: '83'
+        }]
+      })
+
+      const { selectMock } = createSelectMock([{
+        rows: [{
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        }],
+        type: 'limit'
+      }, {
+        rows: [{
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }],
+        type: 'limit'
+      }, {
+        rows: [],
+        type: 'limit'
+      }, {
+        rows: [],
+        type: 'where'
+      }])
+      const dbWrite = createWriteDb({
+        insert: vi.fn(),
+        select: selectMock,
+        update: vi.fn()
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+
+      await expect(createSubmissionHandler(event)).rejects.toMatchObject({
+        statusCode: 400
+      })
+    })
+
+    it('should return 400 when enum value is not a category option', async () => {
+      readValidatedBodyMock.mockResolvedValue({
+        brandId: 1,
+        categoryId: 2,
+        name: 'PocketRocket Deluxe',
+
+        properties: [{
+          propertyId: 12,
+          value: 'white-gas'
+        }]
+      })
+
+      const { selectMock } = createSelectMock([{
+        rows: [{
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        }],
+        type: 'limit'
+      }, {
+        rows: [{
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }],
+        type: 'limit'
+      }, {
+        rows: [],
+        type: 'limit'
+      }, {
+        rows: [{
+          dataType: 'enum',
+          id: 12,
+          name: 'Fuel',
+          slug: 'fuel',
+          unit: null
+        }],
+        type: 'where'
+      }, {
+        rows: [{
+          propertyId: 12,
+          slug: 'canister'
+        }],
+        type: 'where'
+      }])
+      const dbWrite = createWriteDb({
+        insert: vi.fn(),
+        select: selectMock,
+        update: vi.fn()
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+
+      await expect(createSubmissionHandler(event)).rejects.toMatchObject({
+        statusCode: 400
+      })
+    })
+
+    it('should return 400 when number value is malformed', async () => {
+      readValidatedBodyMock.mockResolvedValue({
+        brandId: 1,
+        categoryId: 2,
+        name: 'PocketRocket Deluxe',
+
+        properties: [{
+          propertyId: 10,
+          value: '83g'
+        }]
+      })
+
+      const { selectMock } = createSelectMock([{
+        rows: [{
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        }],
+        type: 'limit'
+      }, {
+        rows: [{
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }],
+        type: 'limit'
+      }, {
+        rows: [],
+        type: 'limit'
+      }, {
+        rows: [{
+          dataType: 'number',
+          id: 10,
+          name: 'Weight',
+          slug: 'weight',
+          unit: 'g'
+        }],
+        type: 'where'
+      }])
+      const dbWrite = createWriteDb({
+        insert: vi.fn(),
+        select: selectMock,
+        update: vi.fn()
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+
+      await expect(createSubmissionHandler(event)).rejects.toMatchObject({
+        statusCode: 400
+      })
+    })
+  })
+
+  describe('get /api/equipment/item-submissions', () => {
+    it('should return pending submission summaries for admins', async () => {
+      const rows = [{
+        createdAt: '2026-04-01T00:00:00.000Z',
+        createdBy: userId,
+        id: itemId,
+        name: 'PocketRocket Deluxe',
+        status: 'pending',
+
+        brand: {
+          name: 'MSR',
+          slug: 'msr'
+        },
+
+        category: {
+          name: 'Stoves',
+          slug: 'stoves'
+        }
+      }]
+      const dbHttp = createAdminListDb(rows)
+      const event = createTestEvent(dbHttp)
+      const result = await listSubmissionsHandler(event)
+
+      expect(result).toStrictEqual(rows)
+      expect(validateAdminUserMock).toHaveBeenCalledWith(event)
+    })
+
+    it('should return 403 when list reader is not an admin', async () => {
+      const authError = h3.createError({ status: 403 })
+      const event = createTestEvent(createAdminListDb([]))
+
+      validateAdminUserMock.mockRejectedValue(authError)
+
+      await expect(listSubmissionsHandler(event)).rejects.toMatchObject({
+        statusCode: 403
+      })
+    })
+  })
+
+  describe('patch /api/equipment/item-submissions/[id]', () => {
+    beforeEach(() => {
+      readValidatedBodyMock.mockResolvedValue({
+        status: 'approved'
+      })
+    })
+
+    it('should approve a pending submission and log a contribution', async () => {
+      const { selectMock } = createJoinedSelectMock([{
+        brandName: 'MSR',
+        brandSlug: 'msr',
+        categoryName: 'Stoves',
+        categorySlug: 'stoves',
+        createdAt: '2026-04-01T00:00:00.000Z',
+        createdBy: userId,
+        id: itemId,
+        name: 'PocketRocket Deluxe',
+        status: 'pending'
+      }])
+      const { updateMock, setMock } = createUpdateMock([{
+        status: 'approved'
+      }])
+      const { insertMock, valuesMocks } = createInsertMock([{
+        type: 'values'
+      }])
+      const dbWrite = createWriteDb({
+        insert: insertMock,
+        select: selectMock,
+        update: updateMock
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+      const result = await moderateSubmissionHandler(event)
+
+      expect(result).toStrictEqual({
+        createdAt: '2026-04-01T00:00:00.000Z',
+        createdBy: userId,
+        id: itemId,
+        name: 'PocketRocket Deluxe',
+        status: 'approved',
+
+        brand: {
+          name: 'MSR',
+          slug: 'msr'
+        },
+
+        category: {
+          name: 'Stoves',
+          slug: 'stoves'
+        }
+      })
+      expect(setMock).toHaveBeenCalledWith({
+        status: 'approved'
+      })
+      expect(valuesMocks[0]).toHaveBeenCalledWith({
+        action: 'approve_equipment_item',
+
+        metadata: {
+          previousStatus: 'pending',
+          status: 'approved'
+        },
+
+        targetId: itemId,
+        userId
+      })
+      expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)
+    })
+
+    it('should reject a pending submission and log a contribution', async () => {
+      readValidatedBodyMock.mockResolvedValue({
+        status: 'rejected'
+      })
+
+      const { selectMock } = createJoinedSelectMock([{
+        brandName: 'MSR',
+        brandSlug: 'msr',
+        categoryName: 'Stoves',
+        categorySlug: 'stoves',
+        createdAt: '2026-04-01T00:00:00.000Z',
+        createdBy: userId,
+        id: itemId,
+        name: 'PocketRocket Deluxe',
+        status: 'pending'
+      }])
+      const { updateMock } = createUpdateMock([{
+        status: 'rejected'
+      }])
+      const { insertMock, valuesMocks } = createInsertMock([{
+        type: 'values'
+      }])
+      const dbWrite = createWriteDb({
+        insert: insertMock,
+        select: selectMock,
+        update: updateMock
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+      const result = await moderateSubmissionHandler(event)
+
+      expect(result.status).toBe('rejected')
+      expect(valuesMocks[0]).toHaveBeenCalledWith({
+        action: 'reject_equipment_item',
+
+        metadata: {
+          previousStatus: 'pending',
+          status: 'rejected'
+        },
+
+        targetId: itemId,
+        userId
+      })
+    })
+
+    it('should return 409 when submission is not pending', async () => {
+      const { selectMock } = createJoinedSelectMock([{
+        brandName: 'MSR',
+        brandSlug: 'msr',
+        categoryName: 'Stoves',
+        categorySlug: 'stoves',
+        createdAt: '2026-04-01T00:00:00.000Z',
+        createdBy: userId,
+        id: itemId,
+        name: 'PocketRocket Deluxe',
+        status: 'approved'
+      }])
+      const dbWrite = createWriteDb({
+        insert: vi.fn(),
+        select: selectMock,
+        update: vi.fn()
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+
+      await expect(moderateSubmissionHandler(event)).rejects.toMatchObject({
+        statusCode: 409
+      })
+      expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return 404 when submission does not exist', async () => {
+      const { selectMock } = createJoinedSelectMock([])
+      const dbWrite = createWriteDb({
+        insert: vi.fn(),
+        select: selectMock,
+        update: vi.fn()
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+
+      await expect(moderateSubmissionHandler(event)).rejects.toMatchObject({
+        statusCode: 404
+      })
+    })
+  })
+})

--- a/server/api/equipment/item-submissions/index.get.ts
+++ b/server/api/equipment/item-submissions/index.get.ts
@@ -1,0 +1,58 @@
+import { asc, eq } from 'drizzle-orm'
+import { defineEventHandler } from 'h3'
+
+import {
+  brands,
+  equipmentCategories,
+  equipmentItems
+} from '#server/database/schema'
+
+import { validateAdminUser } from '#server/utils/admin'
+
+interface CatalogEntitySummary {
+  name: string;
+  slug: string;
+}
+
+interface ItemSubmissionSummary {
+  brand: CatalogEntitySummary;
+  category: CatalogEntitySummary;
+  createdAt: Date | string;
+  createdBy: string | null;
+  id: string;
+  name: string;
+  status: string;
+}
+
+export default defineEventHandler(async (event) : Promise<ItemSubmissionSummary[]> => {
+  await validateAdminUser(event)
+
+  return event.context.dbHttp
+    .select({
+      createdAt: equipmentItems.createdAt,
+      createdBy: equipmentItems.createdBy,
+      id: equipmentItems.id,
+      name: equipmentItems.name,
+      status: equipmentItems.status,
+
+      brand: {
+        name: brands.name,
+        slug: brands.slug
+      },
+
+      category: {
+        name: equipmentCategories.name,
+        slug: equipmentCategories.slug
+      }
+    })
+    .from(equipmentItems)
+    .innerJoin(brands, eq(equipmentItems.brandId, brands.id))
+    .innerJoin(equipmentCategories, eq(equipmentItems.categoryId, equipmentCategories.id))
+    .where(
+      eq(equipmentItems.status, 'pending')
+    )
+    .orderBy(
+      asc(equipmentItems.createdAt),
+      asc(equipmentItems.id)
+    )
+})

--- a/server/api/equipment/item-submissions/index.post.ts
+++ b/server/api/equipment/item-submissions/index.post.ts
@@ -1,0 +1,282 @@
+import { and, eq, inArray, ne } from 'drizzle-orm'
+import { createError, defineEventHandler, isError, readValidatedBody, setResponseStatus } from 'h3'
+
+import {
+  brands,
+  categoryProperties,
+  contributions,
+  equipmentCategories,
+  equipmentItems,
+  itemPropertyValues,
+  propertyEnumOptions,
+  userEquipment
+} from '#server/database/schema'
+
+import { createWebSocketClientFromEvent } from '#server/utils/config'
+import {
+  normalizePropertyValues,
+  type SubmittedItemProperty
+} from '#server/utils/equipment/item-submission-properties'
+import { validateSessionUser } from '#server/utils/session'
+import { validateItemSubmissionCreateBody } from '#server/utils/validation/schemas'
+
+interface CatalogEntitySummary {
+  name: string;
+  slug: string;
+}
+
+interface SubmittedItem {
+  brand: CatalogEntitySummary;
+  category: CatalogEntitySummary;
+  createdAt: Date | string;
+  id: string;
+  name: string;
+  properties: SubmittedItemProperty[];
+  status: string;
+}
+
+interface InventoryItemSummary {
+  brand: CatalogEntitySummary;
+  category: CatalogEntitySummary;
+  id: string;
+  name: string;
+}
+
+interface InventoryRecord {
+  createdAt: Date | string;
+  id: string;
+  item: InventoryItemSummary;
+}
+
+interface ItemSubmissionCreateResponse {
+  inventory: InventoryRecord;
+  item: SubmittedItem;
+}
+
+export default defineEventHandler(async (event) : Promise<ItemSubmissionCreateResponse> => {
+  const userId = await validateSessionUser(event)
+  const body = await readValidatedBody(event, validateItemSubmissionCreateBody)
+  const dbWebsocket = createWebSocketClientFromEvent(event)
+
+  try {
+    const response = await dbWebsocket.transaction(async (transaction) => {
+      const [brand] = await transaction
+        .select({
+          id: brands.id,
+          name: brands.name,
+          slug: brands.slug
+        })
+        .from(brands)
+        .where(
+          eq(brands.id, body.brandId)
+        )
+        .limit(1)
+
+      if (brand === undefined) {
+        throw createError({ status: 404 })
+      }
+
+      const [category] = await transaction
+        .select({
+          id: equipmentCategories.id,
+          name: equipmentCategories.name,
+          slug: equipmentCategories.slug
+        })
+        .from(equipmentCategories)
+        .where(
+          eq(equipmentCategories.id, body.categoryId)
+        )
+        .limit(1)
+
+      if (category === undefined) {
+        throw createError({ status: 404 })
+      }
+
+      const [duplicateItem] = await transaction
+        .select({
+          id: equipmentItems.id
+        })
+        .from(equipmentItems)
+        .where(
+          and(
+            eq(equipmentItems.brandId, body.brandId),
+            eq(equipmentItems.categoryId, body.categoryId),
+            eq(equipmentItems.name, body.name),
+            ne(equipmentItems.status, 'rejected')
+          )
+        )
+        .limit(1)
+
+      if (duplicateItem !== undefined) {
+        throw createError({
+          status: 409,
+          message: 'Item already exists or is already pending review'
+        })
+      }
+
+      const categoryPropertiesList = await transaction
+        .select({
+          dataType: categoryProperties.dataType,
+          id: categoryProperties.id,
+          name: categoryProperties.name,
+          slug: categoryProperties.slug,
+          unit: categoryProperties.unit
+        })
+        .from(categoryProperties)
+        .where(
+          eq(categoryProperties.categoryId, body.categoryId)
+        )
+
+      const enumPropertyIds = categoryPropertiesList
+        .filter((property) => property.dataType === 'enum')
+        .map((property) => property.id)
+
+      const enumOptions = enumPropertyIds.length === 0
+        ? []
+        : await transaction
+          .select({
+            propertyId: propertyEnumOptions.propertyId,
+            slug: propertyEnumOptions.slug
+          })
+          .from(propertyEnumOptions)
+          .where(
+            inArray(propertyEnumOptions.propertyId, enumPropertyIds)
+          )
+
+      const normalizedProperties = normalizePropertyValues(
+        categoryPropertiesList,
+        enumOptions,
+        body.properties
+      )
+
+      const [createdItem] = await transaction
+        .insert(equipmentItems)
+        .values({
+          brandId: body.brandId,
+          categoryId: body.categoryId,
+          createdBy: userId,
+          name: body.name,
+          status: 'pending'
+        })
+        .returning({
+          createdAt: equipmentItems.createdAt,
+          id: equipmentItems.id,
+          name: equipmentItems.name,
+          status: equipmentItems.status
+        })
+
+      if (createdItem === undefined) {
+        throw createError({
+          status: 500,
+          message: 'Failed to create submitted item'
+        })
+      }
+
+      const propertyValueRows = normalizedProperties.map((property) => {
+        return {
+          itemId: createdItem.id,
+          propertyId: property.propertyId,
+          valueBoolean: property.valueBoolean,
+          valueNumber: property.valueNumber,
+          valueText: property.valueText
+        }
+      })
+
+      if (propertyValueRows.length > 0) {
+        await transaction
+          .insert(itemPropertyValues)
+          .values(propertyValueRows)
+      }
+
+      const [inventoryRow] = await transaction
+        .insert(userEquipment)
+        .values({
+          itemId: createdItem.id,
+          userId
+        })
+        .returning({
+          createdAt: userEquipment.createdAt,
+          id: userEquipment.id
+        })
+
+      if (inventoryRow === undefined) {
+        throw createError({
+          status: 500,
+          message: 'Failed to create inventory row'
+        })
+      }
+
+      await transaction
+        .insert(contributions)
+        .values({
+          action: 'submit_equipment_item',
+
+          metadata: {
+            brandId: body.brandId,
+            categoryId: body.categoryId,
+            name: createdItem.name,
+            propertyCount: normalizedProperties.length,
+            status: createdItem.status
+          },
+
+          targetId: createdItem.id,
+          userId
+        })
+
+      return {
+        inventory: {
+          createdAt: inventoryRow.createdAt,
+          id: inventoryRow.id,
+
+          item: {
+            brand: {
+              name: brand.name,
+              slug: brand.slug
+            },
+
+            category: {
+              name: category.name,
+              slug: category.slug
+            },
+
+            id: createdItem.id,
+            name: createdItem.name
+          }
+        },
+
+        item: {
+          brand: {
+            name: brand.name,
+            slug: brand.slug
+          },
+
+          category: {
+            name: category.name,
+            slug: category.slug
+          },
+
+          createdAt: createdItem.createdAt,
+          id: createdItem.id,
+          name: createdItem.name,
+          properties: normalizedProperties.map((property) => property.display),
+          status: createdItem.status
+        }
+      }
+    })
+
+    setResponseStatus(event, 201)
+
+    return response
+  } catch (error) {
+    if (isError(error)) {
+      throw error
+    }
+
+    throw createError({
+      status: 500,
+      message: 'Failed to submit item'
+    })
+  } finally {
+    await dbWebsocket.$client.end()
+  }
+})

--- a/server/api/equipment/items/[id].get.ts
+++ b/server/api/equipment/items/[id].get.ts
@@ -1,4 +1,5 @@
 import { createError, defineEventHandler, getValidatedRouterParams } from 'h3'
+import { validateSessionUser } from '#server/utils/session'
 import { validateItemDetailParams } from '#server/utils/validation/schemas'
 
 interface ItemDetailBrand {
@@ -32,11 +33,13 @@ interface ItemDetailResponse {
 }
 
 export default defineEventHandler(async (event) : Promise<ItemDetailResponse> => {
+  const userId = await validateSessionUser(event)
   const { id } = await getValidatedRouterParams(event, validateItemDetailParams)
 
   const item = await event.context.dbHttp.query.equipmentItems.findFirst({
     columns: {
       createdAt: true,
+      createdBy: true,
       id: true,
       name: true,
       status: true
@@ -86,6 +89,26 @@ export default defineEventHandler(async (event) : Promise<ItemDetailResponse> =>
 
   if (item === undefined) {
     throw createError({ status: 404 })
+  }
+
+  const isApproved = item.status === 'approved'
+  const isCreator = item.createdBy === userId
+
+  if (isApproved === false && isCreator === false) {
+    const currentUser = await event.context.dbHttp.query.users.findFirst({
+      columns: {
+        isAdmin: true
+      },
+
+      where: {
+        id: userId
+      }
+    })
+    const isAdmin = currentUser?.isAdmin === true
+
+    if (isAdmin === false) {
+      throw createError({ status: 404 })
+    }
   }
 
   if (item.brand === null || item.category === null) {

--- a/server/api/equipment/items/__tests__/reads.test.ts
+++ b/server/api/equipment/items/__tests__/reads.test.ts
@@ -6,11 +6,13 @@ import { createTestEvent } from '~~/test-utils/create-test-event'
 
 const {
   getValidatedQueryMock,
-  getValidatedRouterParamsMock
+  getValidatedRouterParamsMock,
+  validateSessionUserMock
 } = vi.hoisted(() => {
   return {
     getValidatedQueryMock: vi.fn<typeof h3.getValidatedQuery>(),
-    getValidatedRouterParamsMock: vi.fn<typeof h3.getValidatedRouterParams>()
+    getValidatedRouterParamsMock: vi.fn<typeof h3.getValidatedRouterParams>(),
+    validateSessionUserMock: vi.fn<() => Promise<string>>()
   }
 })
 
@@ -28,6 +30,12 @@ vi.mock(import('h3'), async () => {
     async getValidatedRouterParams(...args: Parameters<typeof h3.getValidatedRouterParams>) {
       return getValidatedRouterParamsMock(...args)
     }
+  }
+})
+
+vi.mock(import('#server/utils/session'), () => {
+  return {
+    validateSessionUser: validateSessionUserMock
   }
 })
 
@@ -118,18 +126,24 @@ function createListDb({
   }
 }
 
-function createDetailDb(item?: unknown) {
+function createDetailDb(item?: unknown, currentUser?: unknown) {
   const findFirstMock = vi.fn(() => item)
+  const userFindFirstMock = vi.fn(() => currentUser)
 
   return {
     dbHttp: {
       query: {
         equipmentItems: {
           findFirst: findFirstMock
+        },
+
+        users: {
+          findFirst: userFindFirstMock
         }
       }
     },
-    findFirstMock
+    findFirstMock,
+    userFindFirstMock
   }
 }
 
@@ -148,6 +162,8 @@ describe('item read handlers', () => {
     getValidatedRouterParamsMock.mockResolvedValue({
       id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
     })
+
+    validateSessionUserMock.mockResolvedValue('0195f6e8-8f44-74f6-bc9a-5c8f7df477aa')
   })
 
   afterEach(() => {
@@ -261,6 +277,7 @@ describe('item read handlers', () => {
   describe('get /api/equipment/items/[id]', () => {
     it('should return item detail with normalized property values', async () => {
       const item = {
+        createdBy: null,
         createdAt: '2026-04-01T00:00:00Z',
         id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
         name: 'PocketRocket Deluxe',
@@ -364,6 +381,131 @@ describe('item read handlers', () => {
       })
 
       expect(findFirstMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return pending item detail to the creator', async () => {
+      const item = {
+        createdBy: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa',
+        createdAt: '2026-04-01T00:00:00Z',
+        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+        name: 'Submitted Stove',
+        propertyValues: [],
+        status: 'pending',
+
+        brand: {
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        },
+
+        category: {
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }
+      }
+
+      const { dbHttp, userFindFirstMock } = createDetailDb(item)
+      const event = createTestEvent(dbHttp)
+      const result = await itemDetailHandler(event)
+
+      expect(result.status).toBe('pending')
+      expect(result.name).toBe('Submitted Stove')
+      expect(userFindFirstMock).not.toHaveBeenCalled()
+    })
+
+    it('should return rejected item detail to the creator', async () => {
+      const item = {
+        createdBy: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa',
+        createdAt: '2026-04-01T00:00:00Z',
+        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+        name: 'Rejected Stove',
+        propertyValues: [],
+        status: 'rejected',
+
+        brand: {
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        },
+
+        category: {
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }
+      }
+
+      const { dbHttp } = createDetailDb(item)
+      const event = createTestEvent(dbHttp)
+      const result = await itemDetailHandler(event)
+
+      expect(result.status).toBe('rejected')
+      expect(result.name).toBe('Rejected Stove')
+    })
+
+    it('should return pending item detail to an admin', async () => {
+      const item = {
+        createdBy: '0195f6e8-8f44-74f6-bc9a-5c8f7df477bb',
+        createdAt: '2026-04-01T00:00:00Z',
+        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+        name: 'Pending Stove',
+        propertyValues: [],
+        status: 'pending',
+
+        brand: {
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        },
+
+        category: {
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }
+      }
+
+      const { dbHttp, userFindFirstMock } = createDetailDb(item, {
+        isAdmin: true
+      })
+      const event = createTestEvent(dbHttp)
+      const result = await itemDetailHandler(event)
+
+      expect(result.status).toBe('pending')
+      expect(userFindFirstMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should hide pending item detail from another non-admin user', async () => {
+      const item = {
+        createdBy: '0195f6e8-8f44-74f6-bc9a-5c8f7df477bb',
+        createdAt: '2026-04-01T00:00:00Z',
+        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+        name: 'Pending Stove',
+        propertyValues: [],
+        status: 'pending',
+
+        brand: {
+          id: 1,
+          name: 'MSR',
+          slug: 'msr'
+        },
+
+        category: {
+          id: 2,
+          name: 'Stoves',
+          slug: 'stoves'
+        }
+      }
+
+      const { dbHttp } = createDetailDb(item, {
+        isAdmin: false
+      })
+      const event = createTestEvent(dbHttp)
+
+      await expect(itemDetailHandler(event)).rejects.toMatchObject({
+        statusCode: 404
+      })
     })
 
     it('should return 400 when route params validation fails', async () => {

--- a/server/utils/equipment/item-submission-properties.ts
+++ b/server/utils/equipment/item-submission-properties.ts
@@ -1,0 +1,220 @@
+import { createError } from 'h3'
+
+interface CategoryPropertyRecord {
+  dataType: string;
+  id: number;
+  name: string;
+  slug: string;
+  unit: string | null;
+}
+
+interface EnumOptionRecord {
+  propertyId: number;
+  slug: string;
+}
+
+interface SubmittedItemProperty {
+  dataType: string;
+  name: string;
+  slug: string;
+  unit: string | null;
+  value: string;
+}
+
+interface NormalizedPropertyValue {
+  display: SubmittedItemProperty;
+  propertyId: number;
+  valueBoolean: boolean | null;
+  valueNumber: string | null;
+  valueText: string | null;
+}
+
+interface SubmittedPropertyInput {
+  propertyId: number;
+  value: boolean | string;
+}
+
+const numberValuePattern = /^-?\d+(?:\.\d+)?$/u
+
+function getPropertyRecord(
+  propertyById: Map<number, CategoryPropertyRecord>,
+  propertyId: number
+) {
+  const property = propertyById.get(propertyId)
+
+  if (property === undefined) {
+    throw createError({
+      status: 400,
+      message: 'Property does not belong to selected category'
+    })
+  }
+
+  return property
+}
+
+function assertStringValue(value: boolean | string, message: string) {
+  if (typeof value !== 'string') {
+    throw createError({
+      status: 400,
+      message
+    })
+  }
+
+  return value
+}
+
+function normalizeTextProperty(
+  property: CategoryPropertyRecord,
+  value: boolean | string
+): NormalizedPropertyValue {
+  const textValue = assertStringValue(value, 'Text property value must be a string')
+
+  return {
+    display: {
+      dataType: property.dataType,
+      name: property.name,
+      slug: property.slug,
+      unit: property.unit,
+      value: textValue
+    },
+    propertyId: property.id,
+    valueBoolean: null,
+    valueNumber: null,
+    valueText: textValue
+  }
+}
+
+function normalizeNumberProperty(
+  property: CategoryPropertyRecord,
+  value: boolean | string
+): NormalizedPropertyValue {
+  const numberValue = assertStringValue(value, 'Number property value must be a decimal string')
+  const isNumberValue = numberValuePattern.test(numberValue)
+
+  if (isNumberValue === false) {
+    throw createError({
+      status: 400,
+      message: 'Number property value must be a decimal string'
+    })
+  }
+
+  return {
+    display: {
+      dataType: property.dataType,
+      name: property.name,
+      slug: property.slug,
+      unit: property.unit,
+      value: numberValue
+    },
+    propertyId: property.id,
+    valueBoolean: null,
+    valueNumber: numberValue,
+    valueText: null
+  }
+}
+
+function normalizeBooleanProperty(
+  property: CategoryPropertyRecord,
+  value: boolean | string
+): NormalizedPropertyValue {
+  if (typeof value !== 'boolean') {
+    throw createError({
+      status: 400,
+      message: 'Boolean property value must be a boolean'
+    })
+  }
+
+  return {
+    display: {
+      dataType: property.dataType,
+      name: property.name,
+      slug: property.slug,
+      unit: property.unit,
+      value: String(value)
+    },
+    propertyId: property.id,
+    valueBoolean: value,
+    valueNumber: null,
+    valueText: null
+  }
+}
+
+function normalizeEnumProperty(
+  enumOptionKeys: Set<string>,
+  property: CategoryPropertyRecord,
+  value: boolean | string
+): NormalizedPropertyValue {
+  const enumSlug = assertStringValue(value, 'Enum property value must be an option slug')
+  const enumOptionKey = `${property.id}:${enumSlug}`
+
+  if (enumOptionKeys.has(enumOptionKey) === false) {
+    throw createError({
+      status: 400,
+      message: 'Enum property value must match a category option'
+    })
+  }
+
+  return {
+    display: {
+      dataType: property.dataType,
+      name: property.name,
+      slug: property.slug,
+      unit: property.unit,
+      value: enumSlug
+    },
+    propertyId: property.id,
+    valueBoolean: null,
+    valueNumber: null,
+    valueText: enumSlug
+  }
+}
+
+function normalizePropertyValues(
+  categoryPropertiesList: CategoryPropertyRecord[],
+  enumOptions: EnumOptionRecord[],
+  submittedProperties: SubmittedPropertyInput[]
+) {
+  const propertyById = new Map(
+    categoryPropertiesList.map((property) => [
+      property.id,
+      property
+    ])
+  )
+  const enumOptionKeys = new Set(
+    enumOptions.map((option) => `${option.propertyId}:${option.slug}`)
+  )
+
+  return submittedProperties.map((submittedProperty) => {
+    const property = getPropertyRecord(propertyById, submittedProperty.propertyId)
+
+    if (property.dataType === 'text') {
+      return normalizeTextProperty(property, submittedProperty.value)
+    }
+
+    if (property.dataType === 'number') {
+      return normalizeNumberProperty(property, submittedProperty.value)
+    }
+
+    if (property.dataType === 'boolean') {
+      return normalizeBooleanProperty(property, submittedProperty.value)
+    }
+
+    if (property.dataType === 'enum') {
+      return normalizeEnumProperty(enumOptionKeys, property, submittedProperty.value)
+    }
+
+    throw createError({
+      status: 500,
+      message: 'Unsupported property data type'
+    })
+  })
+}
+
+export {
+  normalizePropertyValues,
+  type CategoryPropertyRecord,
+  type EnumOptionRecord,
+  type NormalizedPropertyValue,
+  type SubmittedItemProperty,
+  type SubmittedPropertyInput
+}

--- a/server/utils/validation/__tests__/schemas.test.ts
+++ b/server/utils/validation/__tests__/schemas.test.ts
@@ -14,6 +14,8 @@ import {
   validateGroupIdParams,
   validateGroupMutationBody,
   validateItemDetailParams,
+  validateItemSubmissionCreateBody,
+  validateItemSubmissionModerationBody,
   validateItemsListQuery,
   validatePackingListEntryCreateBody,
   validatePackingListEntryParams,
@@ -47,6 +49,8 @@ describe('validation schemas', () => {
   const maxGroupSlug = 'g'.repeat(limits.maxEquipmentGroupSlugLength)
   const tooLongGroupName = 'G'.repeat(limits.maxEquipmentGroupNameLength + 1)
   const tooLongGroupSlug = 'g'.repeat(limits.maxEquipmentGroupSlugLength + 1)
+  const maxEquipmentItemName = 'I'.repeat(limits.maxEquipmentItemNameLength)
+  const tooLongEquipmentItemName = 'I'.repeat(limits.maxEquipmentItemNameLength + 1)
   const maxPackingListName = 'P'.repeat(limits.maxPackingListNameLength)
   const tooLongPackingListName = 'P'.repeat(limits.maxPackingListNameLength + 1)
   const maxPackingListEntryCustomName = 'E'.repeat(limits.maxPackingListEntryCustomNameLength)
@@ -744,6 +748,106 @@ describe('validation schemas', () => {
     expect(() => validateItemDetailParams({
       id: '550e8400-e29b-41d4-a716-446655440000'
     })).toThrow(/./u)
+  })
+
+  it('should trim and validate item submission create bodies', () => {
+    const result = validateItemSubmissionCreateBody({
+      brandId: 1,
+      categoryId: 2,
+      name: '  PocketRocket Deluxe  ',
+
+      properties: [{
+        propertyId: 10,
+        value: ' 83 '
+      }, {
+        propertyId: 11,
+        value: false
+      }]
+    })
+
+    expect(result).toStrictEqual({
+      brandId: 1,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+
+      properties: [{
+        propertyId: 10,
+        value: '83'
+      }, {
+        propertyId: 11,
+        value: false
+      }]
+    })
+  })
+
+  it('should default item submission properties to an empty array', () => {
+    const result = validateItemSubmissionCreateBody({
+      brandId: 1,
+      categoryId: 2,
+      name: maxEquipmentItemName
+    })
+
+    expect(result).toStrictEqual({
+      brandId: 1,
+      categoryId: 2,
+      name: maxEquipmentItemName,
+      properties: []
+    })
+  })
+
+  it.each([{
+    brandId: 0,
+    categoryId: 2,
+    name: 'PocketRocket Deluxe'
+  }, {
+    brandId: 1,
+    categoryId: '2',
+    name: 'PocketRocket Deluxe'
+  }, {
+    brandId: 1,
+    categoryId: 2,
+    name: '   '
+  }, {
+    brandId: 1,
+    categoryId: 2,
+    name: tooLongEquipmentItemName
+  }, {
+    brandId: 1,
+    categoryId: 2,
+    name: 'PocketRocket Deluxe',
+
+    properties: [{
+      propertyId: 10,
+      value: '83'
+    }, {
+      propertyId: 10,
+      value: '84'
+    }]
+  }, {
+    brandId: 1,
+    categoryId: 2,
+    name: 'PocketRocket Deluxe',
+
+    properties: [{
+      propertyId: 10,
+      value: ''
+    }]
+  }])('should reject invalid item submission create bodies: %j', (body) => {
+    expect(() => validateItemSubmissionCreateBody(body)).toThrow(/./u)
+  })
+
+  it.each(['approved', 'rejected'])('should accept item submission moderation status: %s', (status) => {
+    const result = validateItemSubmissionModerationBody({
+      status
+    })
+
+    expect(result).toStrictEqual({
+      status
+    })
+  })
+
+  it.each([{}, { status: 'pending' }, { status: true }])('should reject invalid item submission moderation bodies: %j', (body) => {
+    expect(() => validateItemSubmissionModerationBody(body)).toThrow(/./u)
   })
 
   it('should accept canonical uuid v7 inventory create bodies only', () => {

--- a/server/utils/validation/schemas.ts
+++ b/server/utils/validation/schemas.ts
@@ -24,6 +24,12 @@ const positiveIntegerIdParamSchema = v.pipe(
   v.toNumber()
 )
 
+const positiveIntegerSchema = v.pipe(
+  v.number(),
+  v.integer(),
+  v.minValue(1)
+)
+
 const canonicalUuidV7Schema = v.pipe(
   v.string(),
   v.regex(/^[\da-f]{8}-[\da-f]{4}-7[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/u)
@@ -200,6 +206,38 @@ const itemDetailParamsSchema = v.object({
   id: canonicalUuidV7Schema
 })
 
+const itemSubmissionPropertySchema = v.object({
+  propertyId: positiveIntegerSchema,
+  value: v.union([
+    trimmedNonEmptyStringSchema,
+    v.boolean()
+  ])
+})
+
+const itemSubmissionCreateBodySchema = v.pipe(
+  v.object({
+    brandId: positiveIntegerSchema,
+    categoryId: positiveIntegerSchema,
+    name: v.pipe(
+      trimmedNonEmptyStringSchema,
+      v.maxLength(limits.maxEquipmentItemNameLength)
+    ),
+    properties: v.optional(v.array(itemSubmissionPropertySchema), [])
+  }),
+  v.check((body) => {
+    const propertyIds = body.properties.map((property) => property.propertyId)
+
+    return new Set(propertyIds).size === propertyIds.length
+  }, 'properties must contain unique propertyId values')
+)
+
+const itemSubmissionModerationBodySchema = v.object({
+  status: v.picklist([
+    'approved',
+    'rejected'
+  ])
+})
+
 const userEquipmentIdParamsSchema = v.object({
   id: canonicalUuidV7Schema
 })
@@ -337,6 +375,14 @@ function validateItemDetailParams(params: unknown) {
   return v.parse(itemDetailParamsSchema, params)
 }
 
+function validateItemSubmissionCreateBody(body: unknown) {
+  return v.parse(itemSubmissionCreateBodySchema, body)
+}
+
+function validateItemSubmissionModerationBody(body: unknown) {
+  return v.parse(itemSubmissionModerationBodySchema, body)
+}
+
 function validateUserEquipmentIdParams(params: unknown) {
   return v.parse(userEquipmentIdParamsSchema, params)
 }
@@ -401,6 +447,8 @@ export {
   groupIdParamsSchema,
   groupMutationSchema,
   itemDetailParamsSchema,
+  itemSubmissionCreateBodySchema,
+  itemSubmissionModerationBodySchema,
   itemsListQuerySchema,
   limitQuerySchema,
   nonEmptyStringSchema,
@@ -433,6 +481,8 @@ export {
   validateGroupIdParams,
   validateGroupMutationBody,
   validateItemDetailParams,
+  validateItemSubmissionCreateBody,
+  validateItemSubmissionModerationBody,
   validateItemsListQuery,
   validatePackingListEntryCreateBody,
   validatePackingListEntryParams,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -10,6 +10,7 @@ const limits = {
   maxEquipmentCategorySlugLength: 128,
   maxEquipmentGroupNameLength: 64,
   maxEquipmentGroupSlugLength: 128,
+  maxEquipmentItemNameLength: 256,
   maxPackingListEntryCustomNameLength: 128,
   maxPackingListNameLength: 128,
   maxPaginatedListLimit: 100,

--- a/tests/playwright/catalog/gear-submissions.test.ts
+++ b/tests/playwright/catalog/gear-submissions.test.ts
@@ -1,0 +1,517 @@
+import { expect, test, type BrowserContext, type Locator, type Page, type Response, type Route } from '@playwright/test'
+import { URL } from 'node:url'
+
+interface CatalogEntityDetail {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface CategoryPropertyDetail {
+  dataType: string;
+  id: number;
+  name: string;
+  slug: string;
+  unit: string | null;
+}
+
+interface CategoryDetailResponse extends CatalogEntityDetail {
+  properties: CategoryPropertyDetail[];
+}
+
+interface CatalogEntitySummary {
+  name: string;
+  slug: string;
+}
+
+interface CatalogListItem {
+  brand: CatalogEntitySummary;
+  category: CatalogEntitySummary;
+  id: string;
+  name: string;
+}
+
+interface CatalogItemsResponse {
+  items: CatalogListItem[];
+  limit: number;
+  page: number;
+  total: number;
+}
+
+interface InventoryItem {
+  brand: CatalogEntitySummary;
+  category: CatalogEntitySummary;
+  id: string;
+  name: string;
+}
+
+interface InventoryRecord {
+  createdAt: string;
+  id: string;
+  item: InventoryItem;
+}
+
+interface SubmittedItem {
+  brand: CatalogEntitySummary;
+  category: CatalogEntitySummary;
+  createdAt: string;
+  id: string;
+  name: string;
+  properties: {
+    dataType: string;
+    name: string;
+    slug: string;
+    unit: string | null;
+    value: string;
+  }[];
+  status: string;
+}
+
+interface ItemSubmissionCreateResponse {
+  inventory: InventoryRecord;
+  item: SubmittedItem;
+}
+
+const submittedItemId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477e1'
+const submittedInventoryId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477e2'
+
+const brandsResponse: CatalogEntityDetail[] = [{
+  id: 1,
+  name: 'MSR',
+  slug: 'msr'
+}]
+
+const categoriesResponse: CatalogEntityDetail[] = [{
+  id: 2,
+  name: 'Stoves',
+  slug: 'stoves'
+}]
+
+const categoryDetailResponse: CategoryDetailResponse = {
+  id: 2,
+  name: 'Stoves',
+  slug: 'stoves',
+
+  properties: [{
+    dataType: 'number',
+    id: 10,
+    name: 'Weight',
+    slug: 'weight',
+    unit: 'g'
+  }]
+}
+
+const catalogItemsResponse: CatalogItemsResponse = {
+  items: [{
+    id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+    name: 'PocketRocket Deluxe',
+
+    brand: {
+      name: 'MSR',
+      slug: 'msr'
+    },
+
+    category: {
+      name: 'Stoves',
+      slug: 'stoves'
+    }
+  }],
+  limit: 20,
+  page: 1,
+  total: 1
+}
+
+const submissionResponse: ItemSubmissionCreateResponse = {
+  inventory: {
+    createdAt: '2026-04-01T00:00:00.000Z',
+    id: submittedInventoryId,
+
+    item: {
+      id: submittedItemId,
+      name: 'Submitted Burner',
+
+      brand: {
+        name: 'MSR',
+        slug: 'msr'
+      },
+
+      category: {
+        name: 'Stoves',
+        slug: 'stoves'
+      }
+    }
+  },
+
+  item: {
+    createdAt: '2026-04-01T00:00:00.000Z',
+    id: submittedItemId,
+    name: 'Submitted Burner',
+
+    brand: {
+      name: 'MSR',
+      slug: 'msr'
+    },
+
+    category: {
+      name: 'Stoves',
+      slug: 'stoves'
+    },
+
+    properties: [{
+      dataType: 'number',
+      name: 'Weight',
+      slug: 'weight',
+      unit: 'g',
+      value: '83'
+    }],
+
+    status: 'pending'
+  }
+}
+
+async function mockGuestLogin(context: BrowserContext) {
+  await context.route('**/api/auth/create-session**', async (route) => {
+    await route.fulfill({
+      status: 201,
+
+      json: {
+        userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
+      }
+    })
+  })
+}
+
+async function mockSubmissionReferenceRoutes(context: BrowserContext) {
+  await context.route('**/api/equipment/brands', async (route) => {
+    await route.fulfill({
+      json: brandsResponse
+    })
+  })
+
+  await context.route('**/api/equipment/categories', async (route) => {
+    await route.fulfill({
+      json: categoriesResponse
+    })
+  })
+
+  await context.route('**/api/equipment/categories/stoves', async (route) => {
+    await route.fulfill({
+      json: categoryDetailResponse
+    })
+  })
+}
+
+async function fulfillFullSubmissionRoute(route: Route) {
+  const requestBody: unknown = route.request().postDataJSON()
+
+  expect(requestBody).toStrictEqual({
+    brandId: 1,
+    categoryId: 2,
+    name: 'Submitted Burner',
+
+    properties: [{
+      propertyId: 10,
+      value: '83'
+    }]
+  })
+
+  await route.fulfill({
+    status: 201,
+    json: submissionResponse
+  })
+}
+
+async function mockFullSubmissionCreateRoute(context: BrowserContext) {
+  await context.route('**/api/equipment/item-submissions', async (route) => {
+    await fulfillFullSubmissionRoute(route)
+  })
+}
+
+async function mockQuickSubmissionCreateRoute(context: BrowserContext) {
+  await context.route('**/api/equipment/item-submissions', async (route) => {
+    const requestBody: unknown = route.request().postDataJSON()
+
+    expect(requestBody).toStrictEqual({
+      brandId: 1,
+      categoryId: 2,
+      name: 'Submitted Burner',
+      properties: []
+    })
+
+    await route.fulfill({
+      status: 201,
+      json: submissionResponse
+    })
+  })
+}
+
+function isSubmissionCreateResponse(response: Response): boolean {
+  const responseUrl = new URL(response.url())
+  const isSubmissionResponse = responseUrl.pathname === '/api/equipment/item-submissions'
+  const isPostRequest = response.request().method() === 'POST'
+
+  return isSubmissionResponse && isPostRequest
+}
+
+async function submitQuickGear(page: Page) {
+  await page.getByRole('button', { name: 'Add gear' }).click()
+  await page.getByLabel('Item name').fill('Submitted Burner')
+  await page.getByLabel('Brand').selectOption({ label: 'MSR' })
+  await page.getByLabel('Category').selectOption({ label: 'Stoves' })
+
+  const responsePromise = page.waitForResponse(isSubmissionCreateResponse)
+
+  await page.getByRole('button', { name: 'Create now' }).click()
+
+  const response = await responsePromise
+
+  expect(response.status()).toBe(201)
+}
+
+async function expectPristineControl(control: Locator) {
+  await expect(control).toHaveValue('')
+
+  await expect.poll(async () => control.evaluate((element) => element.matches(':user-invalid'))).toBe(false)
+}
+
+test.describe('Gear submissions', () => {
+  test('should keep the submission dialog open after a backdrop click', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockSubmissionReferenceRoutes(context)
+
+    await context.route('**/api/equipment/items**', async (route) => {
+      await route.fulfill({
+        json: catalogItemsResponse
+      })
+    })
+
+    await page.goto('/login?redirectTo=/catalog')
+    await page.getByRole('button', { name: 'Guest' }).click()
+    await page.getByRole('button', { name: 'Add gear' }).click()
+
+    await page.getByLabel('Item name').fill('Submitted Burner')
+    await page.mouse.click(10, 10)
+
+    await expect(page.getByRole('heading', { name: 'Add gear' })).toBeVisible()
+    await expect(page.getByLabel('Item name')).toHaveValue('Submitted Burner')
+  })
+
+  test('should submit gear from the catalog without adding it to approved results', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockSubmissionReferenceRoutes(context)
+    await mockQuickSubmissionCreateRoute(context)
+
+    await context.route('**/api/equipment/items**', async (route) => {
+      await route.fulfill({
+        json: catalogItemsResponse
+      })
+    })
+
+    await page.goto('/login?redirectTo=/catalog')
+    await page.getByRole('button', { name: 'Guest' }).click()
+
+    await expect(page).toHaveURL(/\/catalog$/u)
+    await expect(page.getByText('1 item')).toBeVisible()
+    await expect(page.getByRole('link', { name: 'PocketRocket Deluxe' })).toBeVisible()
+
+    await submitQuickGear(page)
+
+    await expect(page.getByRole('link', { name: 'Submitted Burner' })).toBeVisible()
+    await expect(page.getByText('1 item')).toBeVisible()
+  })
+
+  test('should open the full submission page from the dialog with base fields preserved', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockSubmissionReferenceRoutes(context)
+
+    await context.route('**/api/equipment/items**', async (route) => {
+      await route.fulfill({
+        json: catalogItemsResponse
+      })
+    })
+
+    await page.goto('/login?redirectTo=/catalog')
+    await page.getByRole('button', { name: 'Guest' }).click()
+    await page.getByRole('button', { name: 'Add gear' }).click()
+
+    await page.getByLabel('Item name').fill('Submitted Burner')
+    await page.getByLabel('Brand').selectOption({ label: 'MSR' })
+    await page.getByLabel('Category').selectOption({ label: 'Stoves' })
+    await page.getByRole('link', { name: 'Add details on full page' }).click()
+
+    await expect(page).toHaveURL(/\/gear\/new\?name=Submitted\+Burner&brandId=1&categoryId=2$/u)
+    await expect(page.getByLabel('Item name')).toHaveValue('Submitted Burner')
+    await expect(page.getByLabel('Brand')).toHaveValue('1')
+    await expect(page.getByLabel('Category')).toHaveValue('2')
+    await expect(page.getByLabel('Weight')).toBeVisible()
+  })
+
+  test('should reopen the submission dialog with pristine required selects', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockSubmissionReferenceRoutes(context)
+
+    await context.route('**/api/equipment/items**', async (route) => {
+      await route.fulfill({
+        json: catalogItemsResponse
+      })
+    })
+
+    await page.goto('/login?redirectTo=/catalog')
+    await page.getByRole('button', { name: 'Guest' }).click()
+    await page.getByRole('button', { name: 'Add gear' }).click()
+
+    await page.getByLabel('Brand').selectOption({ label: 'MSR' })
+    await page.getByLabel('Category').selectOption({ label: 'Stoves' })
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await page.getByRole('button', { name: 'Add gear' }).click()
+
+    await expectPristineControl(page.getByLabel('Brand'))
+    await expectPristineControl(page.getByLabel('Category'))
+  })
+
+  test('should submit quick gear without loading optional category details', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockQuickSubmissionCreateRoute(context)
+
+    await context.route('**/api/equipment/brands', async (route) => {
+      await route.fulfill({
+        json: brandsResponse
+      })
+    })
+
+    await context.route('**/api/equipment/categories', async (route) => {
+      await route.fulfill({
+        json: categoriesResponse
+      })
+    })
+
+    await context.route('**/api/equipment/categories/stoves', async (route) => {
+      await route.fulfill({
+        status: 500,
+        json: {
+          message: 'Category details failed'
+        }
+      })
+    })
+
+    await context.route('**/api/equipment/items**', async (route) => {
+      await route.fulfill({
+        json: catalogItemsResponse
+      })
+    })
+
+    await page.goto('/login?redirectTo=/catalog')
+    await page.getByRole('button', { name: 'Guest' }).click()
+    await page.getByRole('button', { name: 'Add gear' }).click()
+
+    await page.getByLabel('Item name').fill('Submitted Burner')
+    await page.getByLabel('Brand').selectOption({ label: 'MSR' })
+    await page.getByLabel('Category').selectOption({ label: 'Stoves' })
+
+    const responsePromise = page.waitForResponse(isSubmissionCreateResponse)
+
+    await page.getByRole('button', { name: 'Create now' }).click()
+
+    const response = await responsePromise
+
+    expect(response.status()).toBe(201)
+    await expect(page.getByRole('link', { name: 'Submitted Burner' })).toBeVisible()
+  })
+
+  test('should submit gear from an empty inventory and prepend the new row', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockSubmissionReferenceRoutes(context)
+    await mockQuickSubmissionCreateRoute(context)
+
+    await context.route('**/api/user/equipment', async (route) => {
+      await route.fulfill({
+        json: []
+      })
+    })
+
+    await page.goto('/login?redirectTo=/inventory')
+    await page.getByRole('button', { name: 'Guest' }).click()
+
+    await expect(page).toHaveURL(/\/inventory$/u)
+    await expect(page.getByRole('heading', { name: 'No saved gear yet.' })).toBeVisible()
+
+    await submitQuickGear(page)
+
+    await expect(page.getByText('Submitted Submitted Burner for review.')).toBeVisible()
+    await expect(page.getByText('1 saved item')).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Submitted Burner' })).toBeVisible()
+    await expect(page.getByText('MSR').first()).toBeVisible()
+    await expect(page.getByText('Stoves').first()).toBeVisible()
+  })
+
+  test('should submit gear from the full page with optional details', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockSubmissionReferenceRoutes(context)
+    await mockFullSubmissionCreateRoute(context)
+
+    await page.goto('/login?redirectTo=/gear/new')
+    await page.getByRole('button', { name: 'Guest' }).click()
+
+    await expect(page).toHaveURL(/\/gear\/new$/u)
+
+    await page.getByLabel('Item name').fill('Submitted Burner')
+    await page.getByLabel('Brand').selectOption({ label: 'MSR' })
+    await page.getByLabel('Category').selectOption({ label: 'Stoves' })
+    await page.getByLabel('Weight').fill('83')
+
+    const responsePromise = page.waitForResponse(isSubmissionCreateResponse)
+
+    await page.getByRole('button', { name: 'Submit item' }).click()
+
+    const response = await responsePromise
+
+    expect(response.status()).toBe(201)
+    await expect(page.getByRole('link', { name: 'Submitted Burner' })).toBeVisible()
+    await expect(page.getByText('It is in your inventory now.')).toBeVisible()
+  })
+
+  test('should submit gear from the full page when optional category details fail to load', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockQuickSubmissionCreateRoute(context)
+
+    await context.route('**/api/equipment/brands', async (route) => {
+      await route.fulfill({
+        json: brandsResponse
+      })
+    })
+
+    await context.route('**/api/equipment/categories', async (route) => {
+      await route.fulfill({
+        json: categoriesResponse
+      })
+    })
+
+    await context.route('**/api/equipment/categories/stoves', async (route) => {
+      await route.fulfill({
+        status: 500,
+
+        json: {
+          message: 'Category details failed'
+        }
+      })
+    })
+
+    await page.goto('/login?redirectTo=/gear/new')
+    await page.getByRole('button', { name: 'Guest' }).click()
+
+    await page.getByLabel('Item name').fill('Submitted Burner')
+    await page.getByLabel('Brand').selectOption({ label: 'MSR' })
+    await page.getByLabel('Category').selectOption({ label: 'Stoves' })
+
+    await expect(page.getByText('Optional category details are unavailable.')).toBeVisible()
+
+    const responsePromise = page.waitForResponse(isSubmissionCreateResponse)
+
+    await page.getByRole('button', { name: 'Submit item' }).click()
+
+    const response = await responsePromise
+
+    expect(response.status()).toBe(201)
+    await expect(page.getByRole('link', { name: 'Submitted Burner' })).toBeVisible()
+  })
+})

--- a/tests/playwright/packing-lists/packing-list-shell.test.ts
+++ b/tests/playwright/packing-lists/packing-list-shell.test.ts
@@ -497,6 +497,28 @@ test.describe('Packing list shell', () => {
     await expect(page.getByText('Add custom items or pull from saved gear while you build this pack.')).toBeVisible()
   })
 
+  test('should keep the create pack dialog open after a backdrop click', async ({ context, page }) => {
+    const state: PackingListRouteState = {
+      createRequests: 0,
+      createShouldFail: false,
+      deleteShouldFail: false,
+      inventoryRows: [],
+      rows: []
+    }
+
+    await mockAuth(context)
+    await mockInventoryRoutes(context, state)
+    await mockPackingListRoutes(context, page, state)
+    await openPackingLists(page)
+
+    await page.getByRole('button', { name: 'New pack' }).first().click()
+    await page.getByLabel('Pack name').fill('Alpine weekend')
+    await page.mouse.click(10, 10)
+
+    await expect(page.getByRole('heading', { name: 'Create a pack' })).toBeVisible()
+    await expect(page.getByLabel('Pack name')).toHaveValue('Alpine weekend')
+  })
+
   test('should open pack detail in planning mode from a navigational card', async ({ context, page }) => {
     const state: PackingListRouteState = {
       createRequests: 0,


### PR DESCRIPTION
## Summary

User-submitted gear is finally wired end-to-end for the catalog workflow 😎🧰 This gives authenticated users a clean way to add missing equipment, use it immediately, and still keep the public catalog behind admin review 🔐✨

- ✨ Added `POST /api/equipment/item-submissions` to create pending items, typed property values, inventory rows, and contribution records in one transaction 💪
- 🛡️ Added admin moderation APIs for listing pending submissions and approving or rejecting them with contribution logging ⚙️
- 🔐 Tightened item detail visibility so pending/rejected gear stays visible only to the creator or admins 👀
- 🧰 Added a reusable gear submission dialog to Catalog and Inventory with lazy-loaded brands/categories and optional category properties 🎒
- ✅ Expanded validation, API, detail visibility, and Playwright coverage so the new path has proper guard rails 🧪🔥
- 📚 Refreshed the README feature list and moved gear submissions out of TODO now that the flow exists 🚀

## Why This Matters

The old catalog flow had a hard stop when gear was missing 😤 Users could save approved items, but they could not contribute their own equipment without waiting for a manual catalog update. This slice fixes that gap while keeping catalog quality under control: submitted gear lands in the user inventory right away, then becomes public only after admin approval 🎯

## Notes

No database migration is included here because the existing `status`, `createdBy`, `item_property_values`, `user_equipment`, and `contributions` tables cover this first slice cleanly 👍