### PR TITLE
Add inline packing list item composer

### DIFF
--- a/app/components/PerdIconButton.vue
+++ b/app/components/PerdIconButton.vue
@@ -1,0 +1,107 @@
+<template>
+  <button
+    :type="type"
+    :class="[$style.component, variant]"
+    :aria-label="label"
+    :aria-busy="ariaBusy"
+    :disabled="isButtonDisabled"
+  >
+    <FidgetSpinner
+      v-if="loading"
+      :class="$style.icon"
+      aria-hidden="true"
+    />
+
+    <Icon
+      v-else
+      :name="icon"
+      :class="$style.icon"
+      aria-hidden="true"
+    />
+  </button>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import FidgetSpinner from '~/components/FidgetSpinner.vue'
+
+  interface Props {
+    disabled?: boolean;
+    icon: string;
+    label: string;
+    loading?: boolean;
+    type?: 'button' | 'reset' | 'submit';
+    variant?: 'danger' | 'neutral';
+  }
+
+  const {
+    disabled = false,
+    icon,
+    label,
+    loading = false,
+    type = 'button',
+    variant = 'neutral'
+  } = defineProps<Props>()
+
+  const ariaBusy = computed(() => loading || undefined)
+  const isButtonDisabled = computed(() => disabled || loading)
+</script>
+
+<style module>
+  .component {
+    --icon-button-background-hover: var(--color-surface-tertiary);
+    --icon-button-border-hover: var(--color-border-subtle);
+    --icon-button-color: var(--color-text-muted);
+    --icon-button-color-hover: var(--color-text-primary);
+    --icon-button-focus-shadow: var(--shadow-focus);
+
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 2rem;
+    block-size: 2rem;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: var(--border-radius-6);
+    background: transparent;
+    color: var(--icon-button-color);
+    cursor: pointer;
+    transition:
+      background-color var(--transition-duration-fast) var(--transition-easing-standard),
+      border-color var(--transition-duration-fast) var(--transition-easing-standard),
+      color var(--transition-duration-fast) var(--transition-easing-standard);
+
+    &:hover:not(:disabled) {
+      border-color: var(--icon-button-border-hover);
+      background: var(--icon-button-background-hover);
+      color: var(--icon-button-color-hover);
+    }
+
+    &:focus-visible {
+      border-color: var(--icon-button-border-hover);
+      background: var(--icon-button-background-hover);
+      color: var(--icon-button-color-hover);
+      outline: 0;
+      box-shadow: var(--icon-button-focus-shadow);
+    }
+
+    &:global(.danger) {
+      --icon-button-background-hover: var(--color-danger-subtle);
+      --icon-button-border-hover: var(--color-danger-border);
+      --icon-button-color-hover: var(--color-danger-primary);
+      --icon-button-focus-shadow: 0 0 0 3px color-mix(in oklch, var(--color-danger-primary) 32%, transparent);
+    }
+
+    &:disabled {
+      color: var(--color-text-muted);
+      cursor: not-allowed;
+      opacity: 0.65;
+    }
+  }
+
+  .icon {
+    flex-shrink: 0;
+    font-size: 1rem;
+  }
+</style>

--- a/app/components/packing-lists/PackingListEntryCard.vue
+++ b/app/components/packing-lists/PackingListEntryCard.vue
@@ -1,85 +1,59 @@
 <template>
   <li :class="$style.component">
-    <PerdCard :class="$style.card">
-      <div :class="$style.content">
-        <span :class="$style.icon" aria-hidden="true">
-          <Icon name="hugeicons:package" />
-        </span>
+    <div :class="$style.body">
+      <p :class="$style.title">
+        {{ entry.title }}
+      </p>
 
-        <div :class="$style.body">
-          <p :class="$style.source">
-            {{ entry.sourceText }}
-          </p>
+      <p v-if="hasSubtitle" :class="$style.subtitle">
+        {{ entry.subtitle }}
+      </p>
+    </div>
 
-          <p :class="$style.title">
-            {{ entry.title }}
-          </p>
-
-          <p v-if="hasSubtitle" :class="$style.subtitle">
-            {{ entry.subtitle }}
-          </p>
-        </div>
-
-        <PerdPill :tone="packedStatusTone">
-          {{ entry.packedStatusText }}
-        </PerdPill>
-      </div>
-    </PerdCard>
+    <PerdIconButton
+      icon="hugeicons:delete-02"
+      :label="removeLabel"
+      :loading="entry.isRemoving"
+      :disabled="entry.isRemoveDisabled"
+      variant="danger"
+      @click="emitRemove"
+    />
   </li>
 </template>
 
 <script lang="ts" setup>
   import { computed } from 'vue'
   import type { PackingListEntryView } from '~/types/packing'
-  import PerdCard from '~/components/PerdCard.vue'
-  import PerdPill, { type PerdPillTone } from '~/components/PerdPill.vue'
+  import PerdIconButton from '~/components/PerdIconButton.vue'
 
   interface Props {
     entry: PackingListEntryView;
   }
 
+  type Emits = (event: 'remove', entryId: string) => void
+
   const props = defineProps<Props>()
+  const emit = defineEmits<Emits>()
 
   const hasSubtitle = computed(() => props.entry.subtitle !== '')
-  const packedStatusTone = computed<PerdPillTone>(() => props.entry.isPacked ? 'success' : 'neutral')
+  const removeLabel = computed(() => `Remove ${props.entry.title}`)
+
+  function emitRemove() {
+    emit('remove', props.entry.id)
+  }
 </script>
 
 <style module>
   .component {
-    list-style: none;
-  }
-
-  .card {
-    background:
-      linear-gradient(
-        145deg,
-        color-mix(in oklch, var(--color-accent-primary), transparent 96%),
-        var(--color-surface-primary)
-      );
-  }
-
-  .content {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    align-items: start;
-    gap: var(--spacing-12);
-
-    @container (inline-size >= 34rem) {
-      grid-template-columns: auto minmax(0, 1fr) auto;
-      align-items: center;
-    }
-  }
-
-  .icon {
-    display: inline-flex;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    justify-content: center;
-    inline-size: 2.5rem;
-    block-size: 2.5rem;
-    border-radius: var(--border-radius-16);
-    background-color: var(--color-accent-subtle);
-    color: var(--color-accent-primary);
-    font-size: 1.1rem;
+    gap: var(--spacing-4);
+    padding: var(--spacing-8) var(--spacing-12);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--border-radius-10);
+    background: var(--color-surface-primary);
+    list-style: none;
   }
 
   .body {
@@ -88,20 +62,10 @@
     min-inline-size: 0;
   }
 
-  .source {
-    margin: 0;
-    color: var(--color-text-muted);
-    font-size: var(--font-size-12);
-    font-weight: var(--font-weight-medium);
-    letter-spacing: var(--letter-spacing-label);
-    line-height: var(--line-height-snug);
-    text-transform: uppercase;
-  }
-
   .title {
     margin: 0;
     color: var(--color-text-primary);
-    font-size: var(--font-size-18);
+    font-size: var(--font-size-14);
     font-weight: var(--font-weight-semibold);
     line-height: var(--line-height-snug);
     overflow-wrap: anywhere;
@@ -110,8 +74,9 @@
   .subtitle {
     margin: 0;
     color: var(--color-text-tertiary);
-    font-size: var(--font-size-14);
+    font-size: var(--font-size-12);
     line-height: var(--line-height-snug);
     overflow-wrap: anywhere;
   }
+
 </style>

--- a/app/components/packing-lists/PackingListEntryComposer.vue
+++ b/app/components/packing-lists/PackingListEntryComposer.vue
@@ -1,0 +1,565 @@
+<template>
+  <li :class="$style.component">
+    <details
+      ref="details"
+      :class="$style.details"
+      :open="initiallyOpen"
+      @toggle="handleToggle"
+    >
+      <summary ref="summary" :class="$style.summary" @click="handleSummaryClick">
+        <span :class="$style.summaryIcon" aria-hidden="true">
+          <Icon name="hugeicons:add-01" />
+        </span>
+
+        <span :class="$style.summaryText">
+          <span :class="$style.summaryTitle">{{ summaryTitle }}</span>
+          <span :class="$style.summaryDescription">Search My gear or add a custom item.</span>
+        </span>
+
+        <Icon :name="summaryChevron" :class="$style.summaryChevron" aria-hidden="true" />
+      </summary>
+
+      <div :class="$style.panel" @keydown.esc.prevent.stop="handleEscape">
+        <form :class="$style.searchForm" role="search" @submit.prevent="handleSearchSubmit">
+          <label :class="$style.inputLabel" for="packing-list-entry-search">
+            Find an item
+          </label>
+
+          <p id="packing-list-entry-search-hint" :class="$style.inputHint">
+            Search by item, brand, or category. Your text can also become a custom item.
+          </p>
+
+          <div :class="$style.inputShell">
+            <Icon name="hugeicons:search-01" :class="$style.inputIcon" aria-hidden="true" />
+
+            <input
+              id="packing-list-entry-search"
+              ref="searchInput"
+              v-model="searchQuery"
+              :class="$style.input"
+              :disabled="isMutationPending"
+              :maxlength="maxCustomNameLength"
+              aria-describedby="packing-list-entry-search-hint"
+              name="search"
+              type="text"
+              autocomplete="off"
+              enterkeyhint="search"
+              placeholder="PocketRocket, MSR, Stoves…"
+            >
+
+            <FidgetSpinner v-if="isInitialLoading" :class="$style.spinner" />
+          </div>
+        </form>
+
+        <div :class="$style.results" :aria-busy="ariaBusy">
+          <ul v-if="hasAvailableItems" :class="$style.resultList">
+            <li
+              v-for="item in availableGearItemViews"
+              :key="item.inventoryId"
+              :class="$style.resultItem"
+            >
+              <button
+                type="button"
+                :class="$style.resultButton"
+                :disabled="isResultActionDisabled"
+                @click="handleCreateInventoryEntry(item)"
+              >
+                <span :class="$style.resultText">
+                  <span :class="$style.resultName">{{ item.itemName }}</span>
+                  <span :class="$style.resultMeta">{{ item.meta }}</span>
+                </span>
+
+                <FidgetSpinner v-if="item.isLoading" :class="$style.spinner" />
+                <span v-else :class="$style.resultAction">Add</span>
+              </button>
+            </li>
+          </ul>
+
+          <p v-if="showEmptyMessage" :class="$style.helperMessage">
+            {{ emptyMessage }}
+          </p>
+
+          <button
+            v-if="showCustomAction"
+            type="button"
+            :class="[$style.resultButton, $style.customButton]"
+            :disabled="isResultActionDisabled"
+            @click="handleCreateCustomEntry"
+          >
+            <span :class="$style.customIcon" aria-hidden="true">
+              <Icon name="hugeicons:add-circle" />
+            </span>
+
+            <span :class="$style.customText">{{ customActionText }}</span>
+            <FidgetSpinner v-if="isCreatingCustomEntry" :class="$style.spinner" />
+          </button>
+
+          <div v-if="hasLoadError" :class="$style.messageBlock">
+            <p :class="$style.errorMessage" role="alert">
+              {{ loadErrorMessage }}
+            </p>
+
+            <PerdButton size="small" variant="secondary" @click="handleRetryLoad">
+              Retry
+            </PerdButton>
+          </div>
+
+          <p v-if="hasLoadMoreError" :class="$style.errorMessage" role="alert">
+            {{ loadMoreErrorMessage }}
+          </p>
+
+          <PerdButton
+            v-if="showLoadMore"
+            size="small"
+            variant="secondary"
+            :loading="isLoadingMore"
+            :disabled="isMutationPending"
+            @click="handleLoadMore"
+          >
+            Load more
+          </PerdButton>
+
+          <p v-if="hasMutationError" :class="$style.errorMessage" role="alert">
+            {{ mutationErrorMessage }}
+          </p>
+        </div>
+      </div>
+    </details>
+  </li>
+</template>
+
+<script lang="ts" setup>
+  import { computed, nextTick, onMounted, useTemplateRef } from 'vue'
+  import { limits } from '#shared/constants'
+  import type { PackingListAvailableGearItem, PackingListEntry } from '~/types/packing'
+  import { usePackingListEntryComposer } from '~/composables/use-packing-list-entry-composer'
+  import FidgetSpinner from '~/components/FidgetSpinner.vue'
+  import PerdButton from '~/components/PerdButton.vue'
+
+  interface Props {
+    initiallyOpen?: boolean;
+    packingListId: string;
+  }
+
+  interface AvailableGearItemView extends PackingListAvailableGearItem {
+    isLoading: boolean;
+    meta: string;
+  }
+
+  type Emits = (event: 'created', entry: PackingListEntry, packingListUpdatedAt: string) => void
+
+  const {
+    initiallyOpen = false,
+    packingListId
+  } = defineProps<Props>()
+
+  const emit = defineEmits<Emits>()
+  const detailsRef = useTemplateRef('details')
+  const summaryRef = useTemplateRef('summary')
+  const searchInput = useTemplateRef('searchInput')
+  const maxCustomNameLength = limits.maxPackingListEntryCustomNameLength
+
+  function handleCreated(entry: PackingListEntry, packingListUpdatedAt: string) {
+    emit('created', entry, packingListUpdatedAt)
+  }
+
+  const {
+    ariaBusy,
+    availableGearItems,
+    closeComposer,
+    createCustomEntry,
+    createInventoryEntry,
+    creatingInventoryId,
+    customActionText,
+    emptyMessage,
+    hasAvailableItems,
+    hasLoadError,
+    hasLoadMoreError,
+    hasMutationError,
+    isCreatingCustomEntry,
+    isInitialLoading,
+    isLoadingMore,
+    isMutationPending,
+    isOpen,
+    isResultActionDisabled,
+    loadErrorMessage,
+    loadFirstPage,
+    loadMore,
+    loadMoreErrorMessage,
+    mutationErrorMessage,
+    openComposer,
+    searchQuery,
+    showCustomAction,
+    showEmptyMessage,
+    showLoadMore
+  } = usePackingListEntryComposer({
+    initiallyOpen,
+    onCreated: handleCreated,
+    packingListId
+  })
+
+  const summaryTitle = computed(() => isOpen.value ? 'Add another item' : 'Add item')
+  const summaryChevron = computed(() => isOpen.value ? 'hugeicons:arrow-up-01' : 'hugeicons:arrow-down-01')
+  const availableGearItemViews = computed<AvailableGearItemView[]>(() => availableGearItems.value.map((item) => {
+    return {
+      brand: item.brand,
+      category: item.category,
+      inventoryId: item.inventoryId,
+      isLoading: creatingInventoryId.value === item.inventoryId,
+      itemName: item.itemName,
+      meta: `${item.brand} · ${item.category}`
+    }
+  }))
+
+  async function focusSearchInput() {
+    await nextTick()
+    searchInput.value?.focus()
+  }
+
+  async function handleToggle() {
+    const nextIsOpen = detailsRef.value?.open ?? false
+    const wasOpen = isOpen.value
+
+    if (nextIsOpen === false) {
+      closeComposer()
+
+      return
+    }
+
+    if (wasOpen) {
+      return
+    }
+
+    await openComposer()
+    await focusSearchInput()
+  }
+
+  function handleSummaryClick(event: MouseEvent) {
+    const isClosingDuringMutation = isOpen.value && isMutationPending.value
+
+    if (isClosingDuringMutation) {
+      event.preventDefault()
+    }
+  }
+
+  async function handleEscape() {
+    if (isMutationPending.value) {
+      return
+    }
+
+    const details = detailsRef.value
+
+    if (details === null) {
+      return
+    }
+
+    details.open = false
+    closeComposer()
+
+    await nextTick()
+    summaryRef.value?.focus()
+  }
+
+  async function handleSearchSubmit() {
+    await loadFirstPage(true)
+  }
+
+  async function handleRetryLoad() {
+    await loadFirstPage(true)
+  }
+
+  async function handleLoadMore() {
+    await loadMore()
+  }
+
+  async function handleCreateInventoryEntry(item: PackingListAvailableGearItem) {
+    const wasCreated = await createInventoryEntry(item)
+
+    if (wasCreated) {
+      await focusSearchInput()
+    }
+  }
+
+  async function handleCreateCustomEntry() {
+    const wasCreated = await createCustomEntry()
+
+    if (wasCreated) {
+      await focusSearchInput()
+    }
+  }
+
+  async function refreshAvailableGear() {
+    if (isOpen.value === false) {
+      return
+    }
+
+    await loadFirstPage(true)
+  }
+
+  defineExpose({
+    refreshAvailableGear
+  })
+
+  onMounted(() => {
+    if (initiallyOpen) {
+      void loadFirstPage(true)
+    }
+  })
+</script>
+
+<style module>
+  .component {
+    list-style: none;
+  }
+
+  .details {
+    overflow: clip;
+    border: 1px dashed var(--color-border-strong);
+    border-radius: var(--border-radius-20);
+    background:
+      linear-gradient(
+        145deg,
+        color-mix(in oklch, var(--color-accent-subtle), transparent 74%),
+        var(--color-surface-primary)
+      );
+    transition:
+      border-color var(--transition-duration-fast) var(--transition-easing-standard),
+      box-shadow var(--transition-duration-fast) var(--transition-easing-standard);
+
+    &:has(> .summary:focus-visible) {
+      border-color: var(--color-accent-primary);
+      border-style: solid;
+      box-shadow: var(--shadow-focus);
+    }
+
+    &[open] {
+      border-style: solid;
+      box-shadow: var(--shadow-small);
+    }
+  }
+
+  .summary {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--spacing-12);
+    min-block-size: var(--layout-button-height-medium);
+    padding: var(--spacing-12) var(--spacing-16);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    list-style: none;
+    transition:
+      background-color var(--transition-duration-fast) var(--transition-easing-standard),
+      box-shadow var(--transition-duration-fast) var(--transition-easing-standard);
+
+    &::marker {
+      content: '';
+    }
+
+    &:hover {
+      background: var(--color-surface-secondary);
+    }
+
+    &:focus-visible {
+      box-shadow: none;
+    }
+  }
+
+  .summaryIcon,
+  .customIcon {
+    display: inline-grid;
+    place-items: center;
+    inline-size: 2.5rem;
+    block-size: 2.5rem;
+    border-radius: var(--border-radius-16);
+    background: var(--color-accent-subtle);
+    color: var(--color-accent-primary);
+    font-size: 1.1rem;
+  }
+
+  .summaryText,
+  .resultText {
+    display: grid;
+    gap: var(--spacing-4);
+    min-inline-size: 0;
+  }
+
+  .summaryTitle,
+  .resultName,
+  .customText {
+    font-weight: var(--font-weight-semibold);
+    overflow-wrap: anywhere;
+  }
+
+  .summaryDescription,
+  .resultMeta,
+  .inputHint {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-14);
+    line-height: var(--line-height-snug);
+    overflow-wrap: anywhere;
+  }
+
+  .summaryChevron,
+  .spinner,
+  .inputIcon {
+    color: var(--color-text-muted);
+  }
+
+  .summaryChevron {
+    flex-shrink: 0;
+    font-size: var(--font-size-20);
+  }
+
+  .spinner {
+    flex-shrink: 0;
+    font-size: 1rem;
+  }
+
+  .inputIcon {
+    flex: 0 0 1rem;
+    inline-size: 1rem;
+    block-size: 1rem;
+    font-size: 1rem;
+  }
+
+  .panel {
+    display: grid;
+    gap: var(--spacing-16);
+    padding: var(--spacing-16);
+    border-block-start: 1px solid var(--color-border-subtle);
+  }
+
+  .searchForm,
+  .results {
+    display: grid;
+    gap: var(--spacing-12);
+  }
+
+  .inputLabel {
+    color: var(--color-text-primary);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .inputHint,
+  .helperMessage,
+  .errorMessage {
+    margin: 0;
+  }
+
+  .inputShell {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-8);
+    min-block-size: 3rem;
+    padding-inline: var(--spacing-12);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--border-radius-12);
+    background: var(--color-background-elevated);
+    color: var(--color-text-primary);
+    transition:
+      border-color var(--transition-duration-fast) var(--transition-easing-standard),
+      box-shadow var(--transition-duration-fast) var(--transition-easing-standard);
+
+    &:focus-within {
+      border-color: var(--color-accent-primary);
+      box-shadow: 0 0 0 3px var(--color-focus-ring);
+    }
+  }
+
+  .input {
+    box-sizing: border-box;
+    inline-size: 100%;
+    min-inline-size: 0;
+    min-block-size: 2.75rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    color: var(--color-text-primary);
+    font: inherit;
+    outline: 0;
+
+    &::placeholder {
+      color: var(--color-text-muted);
+    }
+  }
+
+  .resultList {
+    display: grid;
+    gap: var(--spacing-8);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .resultItem {
+    list-style: none;
+  }
+
+  .resultButton {
+    appearance: none;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: var(--spacing-12);
+    inline-size: 100%;
+    min-block-size: var(--layout-button-height-medium);
+    padding: var(--spacing-12) var(--spacing-16);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--border-radius-16);
+    background: var(--color-background-elevated);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    text-align: start;
+    transition:
+      background-color var(--transition-duration-fast) var(--transition-easing-standard),
+      border-color var(--transition-duration-fast) var(--transition-easing-standard),
+      box-shadow var(--transition-duration-fast) var(--transition-easing-standard);
+
+    &:hover:not(:disabled) {
+      border-color: var(--color-accent-border);
+      background: var(--color-accent-subtle);
+    }
+
+    &:focus-visible {
+      border-color: var(--color-accent-primary);
+      box-shadow: var(--shadow-focus);
+    }
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.68;
+    }
+  }
+
+  .resultAction {
+    color: var(--color-accent-primary);
+    font-size: var(--font-size-14);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .customButton {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    border-style: dashed;
+  }
+
+  .helperMessage {
+    color: var(--color-text-tertiary);
+    line-height: var(--line-height-body);
+  }
+
+  .messageBlock {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-12);
+  }
+
+  .errorMessage {
+    color: var(--color-danger-primary);
+    line-height: var(--line-height-body);
+  }
+
+</style>

--- a/app/composables/use-packing-list-entry-composer.ts
+++ b/app/composables/use-packing-list-entry-composer.ts
@@ -1,0 +1,320 @@
+import { computed, onScopeDispose, ref, watch } from 'vue'
+import { watchDebounced } from '@vueuse/core'
+import { useRequestFetch } from '#imports'
+import type { PackingListAvailableGearItem, PackingListEntry } from '~/types/packing'
+
+interface ComposerOptions {
+  initiallyOpen: boolean;
+  onCreated: (entry: PackingListEntry, packingListUpdatedAt: string) => void;
+  packingListId: string;
+}
+
+interface ErrorWithStatus {
+  status?: number;
+  statusCode?: number;
+}
+
+export function usePackingListEntryComposer(options: ComposerOptions) {
+  const requestFetch = useRequestFetch()
+  const availableGearItems = ref<PackingListAvailableGearItem[]>([])
+  const nextPage = ref<number | null>(null)
+  const searchQuery = ref('')
+  const isOpen = ref(options.initiallyOpen)
+  const isInitialLoading = ref(false)
+  const isLoadingMore = ref(false)
+  const creatingInventoryId = ref<string | null>(null)
+  const isCreatingCustomEntry = ref(false)
+  const loadErrorMessage = ref<string | null>(null)
+  const loadMoreErrorMessage = ref<string | null>(null)
+  const mutationErrorMessage = ref<string | null>(null)
+  const loadedSearch = ref<string | null>(null)
+  let activeFetchController: AbortController | null = null
+  let lastRequestedSearch: string | null = null
+
+  const normalizedSearch = computed(() => searchQuery.value.trim())
+  const hasAvailableItems = computed(() => availableGearItems.value.length > 0)
+  const hasLoadError = computed(() => loadErrorMessage.value !== null)
+  const hasLoadMoreError = computed(() => loadMoreErrorMessage.value !== null)
+  const hasMutationError = computed(() => mutationErrorMessage.value !== null)
+  const hasSearchQuery = computed(() => normalizedSearch.value !== '')
+  const isCurrentSearchSettled = computed(() => loadedSearch.value === normalizedSearch.value)
+  const isMutationPending = computed(() => creatingInventoryId.value !== null || isCreatingCustomEntry.value)
+  const isReadPending = computed(() => isInitialLoading.value || isLoadingMore.value)
+  const isResultActionDisabled = computed(() => isMutationPending.value || isReadPending.value)
+  const ariaBusy = computed(() => isReadPending.value || undefined)
+  const showCustomAction = computed(() => hasSearchQuery.value
+    && isInitialLoading.value === false
+    && isCurrentSearchSettled.value)
+  const showEmptyMessage = computed(() => isInitialLoading.value === false
+    && isCurrentSearchSettled.value
+    && hasLoadError.value === false
+    && hasAvailableItems.value === false)
+  const emptyMessage = computed(() => {
+    if (hasSearchQuery.value) {
+      return 'No available My gear matches.'
+    }
+
+    return 'No available My gear items. Type a name to add a custom item.'
+  })
+  const customActionText = computed(() => `Add "${normalizedSearch.value}" as custom item`)
+  const showLoadMore = computed(() => nextPage.value !== null && hasLoadError.value === false)
+
+  function abortActiveFetch() {
+    activeFetchController?.abort()
+  }
+
+  function getErrorStatus(error: unknown) {
+    if (typeof error !== 'object' || error === null) {
+      return
+    }
+
+    const errorWithStatus = error as ErrorWithStatus
+
+    return errorWithStatus.statusCode ?? errorWithStatus.status
+  }
+
+  function resetReadState() {
+    abortActiveFetch()
+
+    activeFetchController = null
+    availableGearItems.value = []
+    nextPage.value = null
+    isInitialLoading.value = false
+    isLoadingMore.value = false
+    loadErrorMessage.value = null
+    loadMoreErrorMessage.value = null
+    lastRequestedSearch = null
+    loadedSearch.value = null
+  }
+
+  async function loadAvailableGear(page: number, replaceItems: boolean) {
+    abortActiveFetch()
+
+    const fetchController = new globalThis.AbortController()
+    const querySearch = normalizedSearch.value
+
+    activeFetchController = fetchController
+    loadErrorMessage.value = null
+    loadMoreErrorMessage.value = null
+
+    if (replaceItems) {
+      isInitialLoading.value = true
+    } else {
+      isLoadingMore.value = true
+    }
+
+    try {
+      const response = await requestFetch(`/api/user/packing-lists/${options.packingListId}/available-gear`, {
+        query: {
+          page,
+          search: querySearch
+        },
+
+        signal: fetchController.signal
+      })
+
+      if (fetchController.signal.aborted) {
+        return
+      }
+
+      availableGearItems.value = replaceItems
+        ? response.items
+        : [
+            ...availableGearItems.value,
+            ...response.items
+          ]
+
+      nextPage.value = response.nextPage
+      loadedSearch.value = querySearch
+    } catch {
+      if (fetchController.signal.aborted) {
+        return
+      }
+
+      if (replaceItems) {
+        loadErrorMessage.value = 'Could not load My gear.'
+        loadedSearch.value = querySearch
+      } else {
+        loadMoreErrorMessage.value = 'Could not load more items.'
+      }
+    } finally {
+      const isCurrentFetch = activeFetchController === fetchController
+
+      if (isCurrentFetch) {
+        activeFetchController = null
+        isInitialLoading.value = false
+        isLoadingMore.value = false
+      }
+    }
+  }
+
+  async function loadFirstPage(force = false) {
+    const querySearch = normalizedSearch.value
+    const isAlreadyRequested = querySearch === lastRequestedSearch
+    const canReuseRequest = isAlreadyRequested && hasLoadError.value === false
+
+    if (force === false && canReuseRequest) {
+      return
+    }
+
+    lastRequestedSearch = querySearch
+    availableGearItems.value = []
+    nextPage.value = null
+
+    await loadAvailableGear(1, true)
+  }
+
+  async function openComposer() {
+    isOpen.value = true
+    await loadFirstPage(true)
+  }
+
+  function closeComposer() {
+    isOpen.value = false
+    searchQuery.value = ''
+    mutationErrorMessage.value = null
+    resetReadState()
+  }
+
+  async function loadMore() {
+    if (nextPage.value === null || isReadPending.value || isMutationPending.value) {
+      return
+    }
+
+    await loadAvailableGear(nextPage.value, false)
+  }
+
+  async function applySuccessfulCreation(entry: PackingListEntry, packingListUpdatedAt: string) {
+    options.onCreated(entry, packingListUpdatedAt)
+
+    if (hasSearchQuery.value) {
+      searchQuery.value = ''
+    } else {
+      await loadFirstPage(true)
+    }
+
+  }
+
+  async function createInventoryEntry(item: PackingListAvailableGearItem) {
+    if (isResultActionDisabled.value) {
+      return false
+    }
+
+    mutationErrorMessage.value = null
+    creatingInventoryId.value = item.inventoryId
+
+    try {
+      const response = await requestFetch(`/api/user/packing-lists/${options.packingListId}/entries`, {
+        method: 'POST',
+
+        body: {
+          inventoryId: item.inventoryId
+        }
+      })
+
+      await applySuccessfulCreation(response.entry, response.packingListUpdatedAt)
+
+      return true
+    } catch (error) {
+      const errorStatus = getErrorStatus(error)
+
+      mutationErrorMessage.value = errorStatus === 409
+        ? 'This item is already in the list.'
+        : 'Could not add item.'
+
+      return false
+    } finally {
+      creatingInventoryId.value = null
+    }
+  }
+
+  async function createCustomEntry() {
+    if (isResultActionDisabled.value || showCustomAction.value === false) {
+      return false
+    }
+
+    const customName = normalizedSearch.value
+
+    mutationErrorMessage.value = null
+    isCreatingCustomEntry.value = true
+
+    try {
+      const response = await requestFetch(`/api/user/packing-lists/${options.packingListId}/entries`, {
+        method: 'POST',
+
+        body: {
+          customName
+        }
+      })
+
+      await applySuccessfulCreation(response.entry, response.packingListUpdatedAt)
+
+      return true
+    } catch {
+      mutationErrorMessage.value = 'Could not add custom item.'
+
+      return false
+    } finally {
+      isCreatingCustomEntry.value = false
+    }
+  }
+
+  watch(searchQuery, () => {
+    abortActiveFetch()
+
+    availableGearItems.value = []
+    nextPage.value = null
+    loadErrorMessage.value = null
+    loadMoreErrorMessage.value = null
+    mutationErrorMessage.value = null
+    lastRequestedSearch = null
+  }, {
+    flush: 'sync'
+  })
+
+  watchDebounced(searchQuery, async () => {
+    if (isOpen.value === false) {
+      return
+    }
+
+    await loadFirstPage()
+  }, {
+    debounce: 250
+  })
+
+  onScopeDispose(() => {
+    abortActiveFetch()
+  })
+
+  return {
+    ariaBusy,
+    availableGearItems,
+    closeComposer,
+    createCustomEntry,
+    createInventoryEntry,
+    creatingInventoryId,
+    customActionText,
+    emptyMessage,
+    hasAvailableItems,
+    hasLoadError,
+    hasLoadMoreError,
+    hasMutationError,
+    isCreatingCustomEntry,
+    isInitialLoading,
+    isLoadingMore,
+    isMutationPending,
+    isOpen,
+    isResultActionDisabled,
+    loadErrorMessage,
+    loadFirstPage,
+    loadMore,
+    loadMoreErrorMessage,
+    mutationErrorMessage,
+    normalizedSearch,
+    openComposer,
+    searchQuery,
+    showCustomAction,
+    showEmptyMessage,
+    showLoadMore
+  }
+}

--- a/app/pages/packing-lists/[id].vue
+++ b/app/pages/packing-lists/[id].vue
@@ -17,28 +17,44 @@
       </PagePlaceholder>
 
       <div v-else :class="$style.content">
-        <PagePlaceholder v-if="isEmpty" emoji="🧾" title="No items yet." />
-
-        <ul v-else :class="$style.entryList">
+        <ul :class="$style.entryList">
           <PackingListEntryCard
             v-for="entry in entryViews"
             :key="entry.id"
             :entry="entry"
+            @remove="handleRemoveEntry"
+          />
+
+          <PackingListEntryComposer
+            ref="entryComposer"
+            :packing-list-id="packingListId"
+            :initially-open="isComposerInitiallyOpen"
+            @created="handleEntryCreated"
           />
         </ul>
+
+        <p
+          v-if="hasEntryRemoveError"
+          :class="$style.errorMessage"
+          role="status"
+          aria-live="polite"
+        >
+          {{ entryRemoveErrorMessage }}
+        </p>
       </div>
     </div>
   </PageContent>
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
-  import { definePageMeta, useFetch, useRoute } from '#imports'
+  import { computed, ref, useTemplateRef } from 'vue'
+  import { definePageMeta, useFetch, useRequestFetch, useRoute } from '#imports'
   import type { PackingListDetail, PackingListEntry, PackingListEntryView, PackingListInventoryEntry } from '~/types/packing'
   import PageLoadingState from '~/components/PageLoadingState.vue'
   import PagePlaceholder from '~/components/PagePlaceholder.vue'
   import PerdButton from '~/components/PerdButton.vue'
   import PageContent from '~/components/layout/PageContent.vue'
+  import PackingListEntryComposer from '~/components/packing-lists/PackingListEntryComposer.vue'
   import PackingListEntryCard from '~/components/packing-lists/PackingListEntryCard.vue'
 
   definePageMeta({
@@ -46,10 +62,14 @@
   })
 
   const route = useRoute()
+  const requestFetch = useRequestFetch()
+  const entryComposerRef = useTemplateRef('entryComposer')
+  const removingEntryId = ref<string | null>(null)
+  const entryRemoveErrorMessage = ref<string | null>(null)
 
   const packingListId = Array.isArray(route.params.id)
     ? route.params.id[0] ?? ''
-    : route.params.id
+    : route.params.id ?? ''
 
   function createDefaultPackingList(): PackingListDetail {
     return {
@@ -71,16 +91,20 @@
   })
 
   const hasPackingListError = computed(() => packingListError.value !== undefined)
+  const hasEntryRemoveError = computed(() => entryRemoveErrorMessage.value !== null)
   const isPackingListLoading = computed(() => packingListStatus.value === 'pending')
-  const isEmpty = computed(() => packingListResponse.value.entries.length === 0)
+  const isComposerInitiallyOpen = packingListResponse.value.entries.length === 0
   const pageTitle = computed(() => packingListResponse.value.name === '' ? 'Packing list' : packingListResponse.value.name)
+
+  function isRemovingAnotherEntry(entryId: string) {
+    return removingEntryId.value !== null && removingEntryId.value !== entryId
+  }
 
   function createCustomEntryView(entry: PackingListEntry): PackingListEntryView {
     return {
       id: entry.id,
-      isPacked: entry.isPacked,
-      packedStatusText: entry.isPacked ? 'Packed' : 'Unpacked',
-      sourceText: 'Custom item',
+      isRemoveDisabled: isRemovingAnotherEntry(entry.id),
+      isRemoving: removingEntryId.value === entry.id,
       subtitle: '',
       title: entry.customName ?? 'Unnamed item'
     }
@@ -89,9 +113,8 @@
   function createInventoryEntryView(entry: PackingListInventoryEntry): PackingListEntryView {
     return {
       id: entry.id,
-      isPacked: entry.isPacked,
-      packedStatusText: entry.isPacked ? 'Packed' : 'Unpacked',
-      sourceText: 'My gear',
+      isRemoveDisabled: isRemovingAnotherEntry(entry.id),
+      isRemoving: removingEntryId.value === entry.id,
       subtitle: `${entry.inventory.brand} / ${entry.inventory.category}`,
       title: entry.inventory.itemName
     }
@@ -110,6 +133,48 @@
   async function handleRetry() {
     await refreshPackingList()
   }
+
+  function handleEntryCreated(entry: PackingListEntry, packingListUpdatedAt: string) {
+    packingListResponse.value = {
+      createdAt: packingListResponse.value.createdAt,
+      entries: [
+        ...packingListResponse.value.entries,
+        entry
+      ],
+      id: packingListResponse.value.id,
+      name: packingListResponse.value.name,
+      updatedAt: packingListUpdatedAt
+    }
+  }
+
+  async function handleRemoveEntry(entryId: string) {
+    if (removingEntryId.value !== null) {
+      return
+    }
+
+    entryRemoveErrorMessage.value = null
+    removingEntryId.value = entryId
+
+    try {
+      const response = await requestFetch(`/api/user/packing-lists/${packingListId}/entries/${entryId}`, {
+        method: 'DELETE'
+      })
+
+      packingListResponse.value = {
+        createdAt: packingListResponse.value.createdAt,
+        entries: packingListResponse.value.entries.filter((entry) => entry.id !== response.deletedEntryId),
+        id: packingListResponse.value.id,
+        name: packingListResponse.value.name,
+        updatedAt: String(response.packingListUpdatedAt)
+      }
+
+      void entryComposerRef.value?.refreshAvailableGear()
+    } catch {
+      entryRemoveErrorMessage.value = 'Could not remove item.'
+    } finally {
+      removingEntryId.value = null
+    }
+  }
 </script>
 
 <style module>
@@ -125,7 +190,14 @@
 
   .entryList {
     display: grid;
-    gap: var(--spacing-16);
+    gap: var(--spacing-8);
+    margin: 0;
     padding: 0;
+  }
+
+  .errorMessage {
+    margin: 0;
+    color: var(--color-danger-primary);
+    font-size: var(--font-size-14);
   }
 </style>

--- a/app/types/packing.ts
+++ b/app/types/packing.ts
@@ -13,6 +13,13 @@ interface PackingListEntryInventory {
   itemName: string;
 }
 
+interface PackingListAvailableGearItem {
+  brand: string;
+  category: string;
+  inventoryId: string;
+  itemName: string;
+}
+
 interface PackingListEntryBase {
   createdAt: string;
   customName: string | null;
@@ -46,14 +53,14 @@ interface PackingListView extends PackingListSummary {
 
 interface PackingListEntryView {
   id: string;
-  isPacked: boolean;
-  packedStatusText: string;
-  sourceText: string;
+  isRemoveDisabled: boolean;
+  isRemoving: boolean;
   subtitle: string;
   title: string;
 }
 
 export type {
+  PackingListAvailableGearItem,
   PackingListDetail,
   PackingListEntry,
   PackingListCustomEntry,

--- a/server/api/user/packing-lists/[id]/available-gear.get.ts
+++ b/server/api/user/packing-lists/[id]/available-gear.get.ts
@@ -1,0 +1,140 @@
+import { and, asc, eq, ilike, isNull, or, sql, type SQL } from 'drizzle-orm'
+import { createError, defineEventHandler, getValidatedQuery, getValidatedRouterParams } from 'h3'
+import {
+  brands,
+  equipmentCategories,
+  equipmentItems,
+  packingListEntries,
+  userEquipment
+} from '#server/database/schema'
+import { validateSessionUser } from '#server/utils/session'
+import {
+  validatePackingListAvailableGearQuery,
+  validatePackingListIdParams
+} from '#server/utils/validation/schemas'
+
+interface AvailableGearItem {
+  brand: string;
+  category: string;
+  inventoryId: string;
+  itemName: string;
+}
+
+interface AvailableGearResponse {
+  items: AvailableGearItem[];
+  nextPage: number | null;
+}
+
+const pageSize = 10
+
+function escapeLikePattern(value: string) {
+  return value
+    .replaceAll('\\', String.raw`\\`)
+    .replaceAll('%', String.raw`\%`)
+    .replaceAll('_', String.raw`\_`)
+}
+
+export default defineEventHandler(async (event) : Promise<AvailableGearResponse> => {
+  const userId = await validateSessionUser(event)
+  const { id } = await getValidatedRouterParams(event, validatePackingListIdParams)
+  const { page, search } = await getValidatedQuery(event, validatePackingListAvailableGearQuery)
+  const { dbHttp } = event.context
+
+  const conditions: SQL[] = [
+    eq(userEquipment.userId, userId),
+    isNull(packingListEntries.id)
+  ]
+
+  const orderBy: SQL[] = []
+
+  if (search === '') {
+    orderBy.push(
+      asc(equipmentItems.name),
+      asc(userEquipment.id)
+    )
+  } else {
+    const escapedSearch = escapeLikePattern(search)
+    const containsPattern = `%${escapedSearch}%`
+    const prefixPattern = `${escapedSearch}%`
+    
+    const searchCondition = or(
+      ilike(equipmentItems.name, containsPattern),
+      ilike(brands.name, containsPattern),
+      ilike(equipmentCategories.name, containsPattern)
+    )
+
+    if (searchCondition !== undefined) {
+      conditions.push(searchCondition)
+    }
+
+    const matchPriority = sql<number>`case
+      when lower(${equipmentItems.name}) = lower(${search}) then 0
+      when ${equipmentItems.name} ilike ${prefixPattern} then 1
+      when ${brands.name} ilike ${prefixPattern} then 2
+      when ${equipmentCategories.name} ilike ${prefixPattern} then 3
+      else 4
+    end`
+
+    orderBy.push(
+      matchPriority,
+      asc(equipmentItems.name),
+      asc(userEquipment.id)
+    )
+  }
+
+  const ownedListPromise = dbHttp.query.packingLists.findFirst({
+    columns: {
+      id: true
+    },
+
+    where: {
+      id,
+      userId
+    }
+  })
+
+  const availableGearPromise = dbHttp
+    .select({
+      brand: brands.name,
+      category: equipmentCategories.name,
+      inventoryId: userEquipment.id,
+      itemName: equipmentItems.name
+    })
+    .from(userEquipment)
+    .innerJoin(equipmentItems, eq(userEquipment.itemId, equipmentItems.id))
+    .innerJoin(brands, eq(equipmentItems.brandId, brands.id))
+    .innerJoin(equipmentCategories, eq(equipmentItems.categoryId, equipmentCategories.id))
+    .leftJoin(
+      packingListEntries,
+      and(
+        eq(packingListEntries.packingListId, id),
+        eq(packingListEntries.userEquipmentId, userEquipment.id)
+      )
+    )
+    .where(
+      and(...conditions)
+    )
+    .orderBy(...orderBy)
+    .limit(pageSize + 1)
+    .offset((page - 1) * pageSize)
+
+  const [ownedList, availableGearRows] = await Promise.all([
+    ownedListPromise,
+    availableGearPromise
+  ])
+
+  if (ownedList === undefined) {
+    throw createError({ status: 404 })
+  }
+
+  const hasNextPage = availableGearRows.length > pageSize
+  const items = hasNextPage
+    ? availableGearRows.slice(0, pageSize)
+    : availableGearRows
+  const nextPage = hasNextPage ? page + 1 : null
+
+  return {
+    items,
+    nextPage
+  }
+})

--- a/server/api/user/packing-lists/__tests__/available-gear.test.ts
+++ b/server/api/user/packing-lists/__tests__/available-gear.test.ts
@@ -1,0 +1,261 @@
+import * as h3 from 'h3'
+import type { SQL } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import listAvailableGearHandler from '#server/api/user/packing-lists/[id]/available-gear.get'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+const {
+  getValidatedQueryMock,
+  getValidatedRouterParamsMock,
+  validateSessionUserMock
+} = vi.hoisted(() => {
+  return {
+    getValidatedQueryMock: vi.fn<typeof h3.getValidatedQuery>(),
+    getValidatedRouterParamsMock: vi.fn<typeof h3.getValidatedRouterParams>(),
+    validateSessionUserMock: vi.fn<(event: unknown) => Promise<string>>()
+  }
+})
+
+// @ts-expect-error -- Vitest's import-based module mock typing rejects this partial h3 mock.
+vi.mock(import('h3'), async () => {
+  const actual = await vi.importActual<typeof h3>('h3')
+
+  return {
+    ...actual,
+
+    async getValidatedQuery(...args: Parameters<typeof h3.getValidatedQuery>) {
+      return getValidatedQueryMock(...args)
+    },
+
+    async getValidatedRouterParams(...args: Parameters<typeof h3.getValidatedRouterParams>) {
+      return getValidatedRouterParamsMock(...args)
+    }
+  }
+})
+
+vi.mock(import('#server/utils/session'), () => {
+  return {
+    validateSessionUser: validateSessionUserMock
+  }
+})
+
+interface AvailableGearRow {
+  brand: string;
+  category: string;
+  inventoryId: string;
+  itemName: string;
+}
+
+interface PackingListFindFirstConfig {
+  columns: unknown;
+  where: unknown;
+}
+
+function expectDefinedSql(value: SQL | undefined): asserts value is SQL {
+  expect(value).toBeDefined()
+}
+
+function createAvailableGearDb({
+  isOwned = true,
+  rows = []
+}: {
+  isOwned?: boolean;
+  rows?: AvailableGearRow[];
+} = {}) {
+  const ownedList = isOwned
+    ? {
+        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+      }
+    : undefined
+  const offsetMock = vi.fn(() => rows)
+  const limitMock = vi.fn(() => {
+    return {
+      offset: offsetMock
+    }
+  })
+  const orderByMock = vi.fn(() => {
+    return {
+      limit: limitMock
+    }
+  })
+  const whereMock = vi.fn((_condition: SQL | undefined) => {
+    return {
+      orderBy: orderByMock
+    }
+  })
+  const leftJoinMock = vi.fn(() => {
+    return {
+      where: whereMock
+    }
+  })
+  const categoryJoinMock = vi.fn(() => {
+    return {
+      leftJoin: leftJoinMock
+    }
+  })
+  const brandJoinMock = vi.fn(() => {
+    return {
+      innerJoin: categoryJoinMock
+    }
+  })
+  const itemJoinMock = vi.fn(() => {
+    return {
+      innerJoin: brandJoinMock
+    }
+  })
+  const fromMock = vi.fn(() => {
+    return {
+      innerJoin: itemJoinMock
+    }
+  })
+  const findFirstMock = vi.fn((_config: PackingListFindFirstConfig) => ownedList)
+
+  return {
+    dbHttp: {
+      query: {
+        packingLists: {
+          findFirst: findFirstMock
+        }
+      },
+
+      select: vi.fn(() => {
+        return {
+          from: fromMock
+        }
+      })
+    },
+    findFirstMock,
+    limitMock,
+    offsetMock,
+    orderByMock,
+    whereMock
+  }
+}
+
+function createAvailableGearRows(count: number): AvailableGearRow[] {
+  return Array.from({ length: count }, (_unusedValue, itemIndex) => {
+    return {
+      brand: 'MSR',
+      category: 'Stoves',
+      inventoryId: `inventory-${itemIndex + 1}`,
+      itemName: `Stove ${itemIndex + 1}`
+    }
+  })
+}
+
+describe('get /api/user/packing-lists/[id]/available-gear', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    validateSessionUserMock.mockResolvedValue('user-1')
+    getValidatedRouterParamsMock.mockResolvedValue({
+      id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+    })
+    getValidatedQueryMock.mockResolvedValue({
+      page: 1,
+      search: ''
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should return the first available gear page and next page number', async () => {
+    const rows = createAvailableGearRows(11)
+    const { dbHttp, findFirstMock, limitMock, offsetMock, orderByMock, whereMock } = createAvailableGearDb({ rows })
+    const event = createTestEvent(dbHttp)
+
+    const result = await listAvailableGearHandler(event)
+
+    expect(result).toStrictEqual({
+      items: rows.slice(0, 10),
+      nextPage: 2
+    })
+    expect(findFirstMock).toHaveBeenCalledWith({
+      columns: {
+        id: true
+      },
+
+      where: {
+        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+        userId: 'user-1'
+      }
+    })
+    expect(whereMock).toHaveBeenCalledTimes(1)
+    expect(orderByMock).toHaveBeenCalledTimes(1)
+    expect(limitMock).toHaveBeenCalledWith(11)
+    expect(offsetMock).toHaveBeenCalledWith(0)
+  })
+
+  it('should escape a searched later page without another page marker', async () => {
+    const rows = createAvailableGearRows(2)
+    const { dbHttp, offsetMock, orderByMock, whereMock } = createAvailableGearDb({ rows })
+    const event = createTestEvent(dbHttp)
+    const search = String.raw`MSR\%_`
+
+    getValidatedQueryMock.mockResolvedValue({
+      page: 3,
+      search
+    })
+
+    const result = await listAvailableGearHandler(event)
+
+    expect(result).toStrictEqual({
+      items: rows,
+      nextPage: null
+    })
+    expect(orderByMock).toHaveBeenCalledTimes(1)
+    expect(offsetMock).toHaveBeenCalledWith(20)
+
+    const whereCondition = whereMock.mock.calls[0]?.[0]
+
+    expectDefinedSql(whereCondition)
+
+    const dialect = new PgDialect()
+    const whereQuery = dialect.sqlToQuery(whereCondition)
+    const escapedContainsPattern = String.raw`%MSR\\\%\_%`
+
+    expect(whereQuery.params).toContain(escapedContainsPattern)
+  })
+
+  it('should return 404 when the packing list is missing or unowned', async () => {
+    const { dbHttp } = createAvailableGearDb({
+      isOwned: false
+    })
+    const event = createTestEvent(dbHttp)
+
+    await expect(listAvailableGearHandler(event)).rejects.toMatchObject({
+      statusCode: 404
+    })
+  })
+
+  it('should return 400 before querying when query validation fails', async () => {
+    const queryError = h3.createError({ status: 400 })
+    const { dbHttp, findFirstMock } = createAvailableGearDb()
+    const event = createTestEvent(dbHttp)
+
+    getValidatedQueryMock.mockRejectedValue(queryError)
+
+    await expect(listAvailableGearHandler(event)).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(findFirstMock).not.toHaveBeenCalled()
+    expect(dbHttp.select).not.toHaveBeenCalled()
+  })
+
+  it('should return 401 before querying when the user is unauthenticated', async () => {
+    const authError = h3.createError({ status: 401 })
+    const { dbHttp, findFirstMock } = createAvailableGearDb()
+    const event = createTestEvent(dbHttp)
+
+    validateSessionUserMock.mockRejectedValue(authError)
+
+    await expect(listAvailableGearHandler(event)).rejects.toMatchObject({
+      statusCode: 401
+    })
+    expect(findFirstMock).not.toHaveBeenCalled()
+    expect(dbHttp.select).not.toHaveBeenCalled()
+  })
+})

--- a/server/utils/validation/__tests__/schemas.test.ts
+++ b/server/utils/validation/__tests__/schemas.test.ts
@@ -15,6 +15,7 @@ import {
   validateGroupMutationBody,
   validateItemDetailParams,
   validateItemsListQuery,
+  validatePackingListAvailableGearQuery,
   validatePackingListEntryCreateBody,
   validatePackingListEntryParams,
   validatePackingListEntryUpdateBody,
@@ -205,6 +206,37 @@ describe('validation schemas', () => {
       expect(() => validatePackingListIdParams(params)).toThrow(/./u)
     }
   )
+
+  it('should normalize available gear queries', () => {
+    const result = validatePackingListAvailableGearQuery({
+      page: '2',
+      search: '  MSR  '
+    })
+
+    expect(result).toStrictEqual({
+      page: 2,
+      search: 'MSR'
+    })
+  })
+
+  it('should use available gear query defaults', () => {
+    const result = validatePackingListAvailableGearQuery({})
+
+    expect(result).toStrictEqual({
+      page: 1,
+      search: ''
+    })
+  })
+
+  it.each([{
+    page: '0'
+  }, {
+    page: 'wat'
+  }, {
+    search: tooLongPackingListEntryCustomName
+  }])('should reject invalid available gear query: %j', (query) => {
+    expect(() => validatePackingListAvailableGearQuery(query)).toThrow(/./u)
+  })
 
   it('should validate packing list entry params', () => {
     const camelCaseResult = validatePackingListEntryParams({

--- a/server/utils/validation/schemas.ts
+++ b/server/utils/validation/schemas.ts
@@ -266,6 +266,15 @@ const packingListEntryUpdateBodySchema = v.object({
   isPacked: v.boolean()
 })
 
+const packingListAvailableGearQuerySchema = v.object({
+  page: pageQuerySchema,
+
+  search: v.pipe(
+    v.optional(trimmedStringSchema, ''),
+    v.maxLength(limits.maxPackingListEntryCustomNameLength)
+  )
+})
+
 const itemsListQuerySchema = v.object({
   brandSlug: optionalFilterQuerySchema,
   categorySlug: optionalFilterQuerySchema,
@@ -365,6 +374,10 @@ function validatePackingListEntryUpdateBody(body: unknown) {
   return v.parse(packingListEntryUpdateBodySchema, body)
 }
 
+function validatePackingListAvailableGearQuery(query: unknown) {
+  return v.parse(packingListAvailableGearQuerySchema, query)
+}
+
 function validatePropertyEnumOptionMutationBody(body: unknown) {
   return v.parse(propertyEnumOptionMutationSchema, body)
 }
@@ -405,6 +418,7 @@ export {
   limitQuerySchema,
   nonEmptyStringSchema,
   pageQuerySchema,
+  packingListAvailableGearQuerySchema,
   packingListEntryCreateBodySchema,
   packingListEntryParamsSchema,
   packingListEntryUpdateBodySchema,
@@ -434,6 +448,7 @@ export {
   validateGroupMutationBody,
   validateItemDetailParams,
   validateItemsListQuery,
+  validatePackingListAvailableGearQuery,
   validatePackingListEntryCreateBody,
   validatePackingListEntryParams,
   validatePackingListEntryUpdateBody,

--- a/tests/playwright/packing-lists/packing-list-shell.test.ts
+++ b/tests/playwright/packing-lists/packing-list-shell.test.ts
@@ -1,5 +1,4 @@
-import { expect, test, type BrowserContext, type Page, type Response, type Route } from '@playwright/test'
-import { URL } from 'node:url'
+import { expect, test, type BrowserContext, type Page, type Request, type Response, type Route } from '@playwright/test'
 
 interface PackingListSummary {
   createdAt: string;
@@ -43,16 +42,45 @@ interface PackingListDetail {
   updatedAt: string;
 }
 
+interface AvailableGearItem {
+  brand: string;
+  category: string;
+  inventoryId: string;
+  itemName: string;
+}
+
+interface AvailableGearResponse {
+  items: AvailableGearItem[];
+  nextPage: number | null;
+}
+
+interface AvailableGearRequest {
+  page: number;
+  search: string;
+}
+
+interface PackingListEntryMutationResponse {
+  entry: PackingListEntry;
+  packingListUpdatedAt: string;
+}
+
 interface PackingListRouteState {
+  availableGearRequests: AvailableGearRequest[];
+  availableGearResponses: Map<string, AvailableGearResponse[]>;
   createRequests: number;
   detail: PackingListDetail;
   detailRequests: number;
+  entryCreateBodies: unknown[];
+  entryCreateResponses: PackingListEntryMutationResponse[];
+  entryDeleteRequests: number;
   getDelayMs: number;
   getRequests: number;
   rows: PackingListSummary[];
 }
 
 const packingListId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+const pocketRocketInventoryId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d9'
+const whisperLiteInventoryId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477da'
 
 function createPackingListSummary(name: string): PackingListSummary {
   return {
@@ -90,7 +118,7 @@ function createPackingListEntries(): PackingListEntry[] {
     inventory: {
       brand: 'MSR',
       category: 'Stoves',
-      inventoryId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d9',
+      inventoryId: pocketRocketInventoryId,
       itemName: 'PocketRocket Deluxe'
     },
 
@@ -100,14 +128,72 @@ function createPackingListEntries(): PackingListEntry[] {
   }]
 }
 
+function createAvailableGearItem(inventoryId: string, itemName: string): AvailableGearItem {
+  return {
+    brand: 'MSR',
+    category: 'Stoves',
+    inventoryId,
+    itemName
+  }
+}
+
+function createInventoryEntryMutation(
+  inventoryId: string,
+  itemName: string,
+  entryId: string
+): PackingListEntryMutationResponse {
+  return {
+    entry: {
+      createdAt: '2026-04-03T09:03:00.000Z',
+      customName: null,
+      id: entryId,
+
+      inventory: {
+        brand: 'MSR',
+        category: 'Stoves',
+        inventoryId,
+        itemName
+      },
+
+      isPacked: false,
+      source: 'inventory',
+      updatedAt: '2026-04-03T09:03:00.000Z'
+    },
+    packingListUpdatedAt: '2026-04-03T09:03:00.000Z'
+  }
+}
+
+function createCustomEntryMutation(customName: string): PackingListEntryMutationResponse {
+  return {
+    entry: {
+      createdAt: '2026-04-03T09:04:00.000Z',
+      customName,
+      id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477e4',
+      isPacked: false,
+      source: 'custom',
+      updatedAt: '2026-04-03T09:04:00.000Z'
+    },
+    packingListUpdatedAt: '2026-04-03T09:04:00.000Z'
+  }
+}
+
+function createAvailableGearKey(search: string, page: number): string {
+  return `${search}:${page}`
+}
+
 function createPackingListRouteState(rows: PackingListSummary[]): PackingListRouteState {
   const [firstRow = createPackingListSummary('Alpine weekend')] = rows
   const detailName = firstRow.name
 
   return {
+    availableGearRequests: [],
+    availableGearResponses: new Map(),
     createRequests: 0,
     detail: createPackingListDetail(detailName),
     detailRequests: 0,
+    entryCreateBodies: [],
+    entryCreateResponses: [],
+    entryDeleteRequests: 0,
     getDelayMs: 0,
     getRequests: 0,
     rows
@@ -115,11 +201,27 @@ function createPackingListRouteState(rows: PackingListSummary[]): PackingListRou
 }
 
 function isPackingListCreateResponse(response: Response): boolean {
-  const responseUrl = new URL(response.url())
+  const responseUrl = new globalThis.URL(response.url())
   const isPackingListCollectionResponse = responseUrl.pathname === '/api/user/packing-lists'
   const isPostRequest = response.request().method() === 'POST'
 
   return isPackingListCollectionResponse && isPostRequest
+}
+
+function isPackingListEntryCreateRequest(request: Request): boolean {
+  const requestUrl = new globalThis.URL(request.url())
+  const isEntryCollectionRequest = requestUrl.pathname.endsWith('/entries')
+  const isPostRequest = request.method() === 'POST'
+
+  return isEntryCollectionRequest && isPostRequest
+}
+
+function isPackingListEntryDeleteResponse(response: Response): boolean {
+  const responseUrl = new globalThis.URL(response.url())
+  const isEntryDeletePath = responseUrl.pathname.includes(`/api/user/packing-lists/${packingListId}/entries/`)
+  const isDeleteRequest = response.request().method() === 'DELETE'
+
+  return isEntryDeletePath && isDeleteRequest
 }
 
 async function fulfillPackingListCollectionRoute(route: Route, page: Page, state: PackingListRouteState): Promise<void> {
@@ -171,12 +273,119 @@ async function fulfillPackingListCollectionRoute(route: Route, page: Page, state
   await route.abort()
 }
 
+async function fulfillAvailableGearRoute(route: Route, requestUrl: URL, state: PackingListRouteState): Promise<void> {
+  const page = Number(requestUrl.searchParams.get('page') ?? '1')
+  const search = requestUrl.searchParams.get('search') ?? ''
+  const responseKey = createAvailableGearKey(search, page)
+  const configuredResponses = state.availableGearResponses.get(responseKey) ?? []
+  const response = configuredResponses.length > 1
+    ? configuredResponses.shift()
+    : configuredResponses[0]
+
+  state.availableGearRequests.push({
+    page,
+    search
+  })
+
+  await route.fulfill({
+    json: response ?? {
+      items: [],
+      nextPage: null
+    }
+  })
+}
+
+async function fulfillEntryCreateRoute(route: Route, state: PackingListRouteState): Promise<void> {
+  const body: unknown = route.request().postDataJSON()
+  const response = state.entryCreateResponses.shift()
+
+  state.entryCreateBodies.push(body)
+
+  if (response === undefined) {
+    await route.fulfill({
+      status: 500,
+
+      json: {
+        message: 'No entry response configured'
+      }
+    })
+
+    return
+  }
+
+  await route.fulfill({
+    status: 201,
+    json: response
+  })
+}
+
+async function fulfillEntryDeleteRoute(route: Route, state: PackingListRouteState): Promise<void> {
+  const requestUrl = new globalThis.URL(route.request().url())
+  const entryId = requestUrl.pathname.split('/').at(-1) ?? ''
+  const entryExists = state.detail.entries.some((entry) => entry.id === entryId)
+
+  state.entryDeleteRequests += 1
+
+  if (entryExists === false) {
+    await route.fulfill({
+      status: 404,
+      json: {
+        statusCode: 404
+      }
+    })
+
+    return
+  }
+
+  state.detail = {
+    createdAt: state.detail.createdAt,
+    entries: state.detail.entries.filter((entry) => entry.id !== entryId),
+    id: state.detail.id,
+    name: state.detail.name,
+    updatedAt: '2026-04-03T09:06:00.000Z'
+  }
+
+  await route.fulfill({
+    status: 200,
+    json: {
+      deletedEntryId: entryId,
+      packingListUpdatedAt: state.detail.updatedAt
+    }
+  })
+}
+
 async function mockPackingListRoutes(context: BrowserContext, page: Page, state: PackingListRouteState): Promise<void> {
   await context.route('**/api/user/packing-lists**', async (route) => {
-    const requestUrl = new URL(route.request().url())
+    const requestUrl = new globalThis.URL(route.request().url())
+    const requestMethod = route.request().method()
+    const detailPath = `/api/user/packing-lists/${packingListId}`
 
     if (requestUrl.pathname === '/api/user/packing-lists') {
       await fulfillPackingListCollectionRoute(route, page, state)
+
+      return
+    }
+
+    if (requestUrl.pathname === `${detailPath}/available-gear` && requestMethod === 'GET') {
+      await fulfillAvailableGearRoute(route, requestUrl, state)
+
+      return
+    }
+
+    if (requestUrl.pathname === `${detailPath}/entries` && requestMethod === 'POST') {
+      await fulfillEntryCreateRoute(route, state)
+
+      return
+    }
+
+    if (requestUrl.pathname.startsWith(`${detailPath}/entries/`) && requestMethod === 'DELETE') {
+      await fulfillEntryDeleteRoute(route, state)
+
+      return
+    }
+
+    if (requestUrl.pathname !== detailPath || requestMethod !== 'GET') {
+      await route.abort()
 
       return
     }
@@ -256,11 +465,201 @@ test.describe('Packing list shell', () => {
     await expect(page.getByText('Rain jacket')).toBeVisible()
     await expect(page.getByText('PocketRocket Deluxe')).toBeVisible()
     await expect(page.getByText('MSR / Stoves')).toBeVisible()
-    await expect(page.getByText('Unpacked', { exact: true })).toBeVisible()
-    await expect(page.getByText('Packed', { exact: true })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Remove Rain jacket' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Remove PocketRocket Deluxe' })).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Planning' })).toHaveCount(0)
     await expect(page.getByRole('heading', { name: 'Checklist' })).toHaveCount(0)
     expect(state.detailRequests).toBe(1)
+  })
+
+  test('should refresh the open item composer after removing an inventory item', async ({ context, page }) => {
+    const state = createPackingListRouteState([createPackingListSummary('Weekend trail')])
+    const availablePocketRocket = createAvailableGearItem(pocketRocketInventoryId, 'PocketRocket Deluxe')
+    const existingEntry: PackingListInventoryEntry = {
+      createdAt: '2026-04-03T09:02:00.000Z',
+      customName: null,
+      id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477e2',
+
+      inventory: {
+        brand: 'MSR',
+        category: 'Stoves',
+        inventoryId: pocketRocketInventoryId,
+        itemName: 'PocketRocket Deluxe'
+      },
+
+      isPacked: true,
+      source: 'inventory',
+      updatedAt: '2026-04-03T09:02:00.000Z'
+    }
+    const firstPageKey = createAvailableGearKey('', 1)
+
+    state.detail = createPackingListDetail('Weekend trail', [existingEntry])
+    state.availableGearResponses.set(firstPageKey, [{
+      items: [],
+      nextPage: null
+    }, {
+      items: [availablePocketRocket],
+      nextPage: null
+    }])
+
+    await mockAuth(context)
+    await mockPackingListRoutes(context, page, state)
+    await openPackingLists(page)
+    await page.getByRole('link', { name: /Weekend trail/iu }).click()
+    await page.getByText('Add item', { exact: true }).click()
+    await expect(page.getByText('No available My gear items. Type a name to add a custom item.')).toBeVisible()
+
+    const deleteResponsePromise = page.waitForResponse(isPackingListEntryDeleteResponse)
+
+    await page.getByRole('button', { name: 'Remove PocketRocket Deluxe' }).click()
+
+    const deleteResponse = await deleteResponsePromise
+    const deleteResponseUrl = new globalThis.URL(deleteResponse.url())
+
+    expect(deleteResponse.status()).toBe(200)
+    expect(deleteResponseUrl.pathname).toBe(`/api/user/packing-lists/${packingListId}/entries/${existingEntry.id}`)
+    expect(state.entryDeleteRequests).toBe(1)
+    await expect(page.getByRole('button', { name: 'Remove PocketRocket Deluxe' })).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /^PocketRocket Deluxe MSR · Stoves Add$/u })).toBeVisible()
+    expect(state.availableGearRequests).toStrictEqual([{
+      page: 1,
+      search: ''
+    }, {
+      page: 1,
+      search: ''
+    }])
+  })
+
+  test('should close the item composer with Escape and restore focus', async ({ context, page }) => {
+    const state = createPackingListRouteState([createPackingListSummary('Keyboard trail')])
+
+    state.detail = createPackingListDetail('Keyboard trail', createPackingListEntries().slice(0, 1))
+
+    await mockAuth(context)
+    await mockPackingListRoutes(context, page, state)
+    await openPackingLists(page)
+    await page.getByRole('link', { name: /Keyboard trail/iu }).click()
+
+    const composerSummary = page.locator('summary').filter({ hasText: 'Add item' })
+    const searchInput = page.getByLabel('Find an item')
+
+    await composerSummary.click()
+    await expect(searchInput).toBeFocused()
+    await searchInput.fill('Rain')
+    await searchInput.press('Escape')
+
+    await expect(searchInput).toBeHidden()
+    await expect(composerSummary).toBeFocused()
+    await expect(page.getByText('Add item', { exact: true })).toBeVisible()
+  })
+
+  test('should lazily load My gear, load another page, and add an inventory item', async ({ context, page }) => {
+    const state = createPackingListRouteState([createPackingListSummary('Alpine weekend')])
+    const pocketRocket = createAvailableGearItem(pocketRocketInventoryId, 'PocketRocket Deluxe')
+    const whisperLite = createAvailableGearItem(whisperLiteInventoryId, 'WhisperLite Universal')
+    const firstPageKey = createAvailableGearKey('', 1)
+    const secondPageKey = createAvailableGearKey('', 2)
+
+    state.detail = createPackingListDetail('Alpine weekend', createPackingListEntries().slice(0, 1))
+    state.availableGearResponses.set(firstPageKey, [{
+      items: [pocketRocket],
+      nextPage: 2
+    }, {
+      items: [],
+      nextPage: null
+    }])
+    state.availableGearResponses.set(secondPageKey, [{
+      items: [whisperLite],
+      nextPage: null
+    }])
+    state.entryCreateResponses.push(createInventoryEntryMutation(
+      whisperLiteInventoryId,
+      'WhisperLite Universal',
+      '0195f6e8-8f44-74f6-bc9a-5c8f7df477e3'
+    ))
+
+    await mockAuth(context)
+    await mockPackingListRoutes(context, page, state)
+    await openPackingLists(page)
+    await page.getByRole('link', { name: /Alpine weekend/iu }).click()
+
+    await expect(page.getByText('Add item', { exact: true })).toBeVisible()
+    expect(state.availableGearRequests).toHaveLength(0)
+
+    await page.getByText('Add item', { exact: true }).click()
+    await expect(page.getByRole('button', { name: /PocketRocket Deluxe/iu })).toBeVisible()
+    expect(state.availableGearRequests).toStrictEqual([{
+      page: 1,
+      search: ''
+    }])
+
+    await page.getByRole('button', { name: 'Load more' }).click()
+    await expect(page.getByRole('button', { name: /WhisperLite Universal/iu })).toBeVisible()
+
+    const createRequestPromise = page.waitForRequest(isPackingListEntryCreateRequest)
+
+    await page.getByRole('button', { name: /WhisperLite Universal/iu }).click()
+    await createRequestPromise
+
+    await expect(page.getByText('WhisperLite Universal', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText('WhisperLite Universal added.', { exact: true })).toHaveCount(0)
+    await expect(page.getByLabel('Find an item')).toBeFocused()
+    expect(state.entryCreateBodies).toStrictEqual([{
+      inventoryId: whisperLiteInventoryId
+    }])
+    expect(state.availableGearRequests).toStrictEqual([{
+      page: 1,
+      search: ''
+    }, {
+      page: 2,
+      search: ''
+    }, {
+      page: 1,
+      search: ''
+    }])
+  })
+
+  test('should debounce search and add the query as a custom item', async ({ context, page }) => {
+    const state = createPackingListRouteState([createPackingListSummary('Alpine weekend')])
+    const customName = 'Emergency blanket'
+    const emptyPage = {
+      items: [],
+      nextPage: null
+    }
+
+    state.detail = createPackingListDetail('Alpine weekend', createPackingListEntries().slice(0, 1))
+    state.availableGearResponses.set(createAvailableGearKey('', 1), [emptyPage])
+    state.availableGearResponses.set(createAvailableGearKey(customName, 1), [emptyPage])
+    state.entryCreateResponses.push(createCustomEntryMutation(customName))
+
+    await mockAuth(context)
+    await mockPackingListRoutes(context, page, state)
+    await openPackingLists(page)
+    await page.getByRole('link', { name: /Alpine weekend/iu }).click()
+    await page.getByText('Add item', { exact: true }).click()
+
+    const searchInput = page.getByLabel('Find an item')
+
+    await searchInput.fill('Emergency')
+    await searchInput.fill(customName)
+    await expect(page.getByRole('button', { name: `Add "${customName}" as custom item` })).toBeVisible()
+
+    const latestAvailableGearRequest = state.availableGearRequests.at(-1)
+
+    expect(latestAvailableGearRequest).toStrictEqual({
+      page: 1,
+      search: customName
+    })
+
+    await page.getByRole('button', { name: `Add "${customName}" as custom item` }).click()
+
+    await expect(page.getByText(customName, { exact: true }).first()).toBeVisible()
+    await expect(page.getByText(`${customName} added.`, { exact: true })).toHaveCount(0)
+    await expect(searchInput).toBeFocused()
+    await expect(searchInput).toHaveValue('')
+    expect(state.entryCreateBodies).toStrictEqual([{
+      customName
+    }])
   })
 
   test('should show an empty item list page', async ({ context, page }) => {
@@ -276,10 +675,15 @@ test.describe('Packing list shell', () => {
 
     await expect(page).toHaveURL(new RegExp(`/packing-lists/${packingListId}$`, 'u'))
     await expect(page.getByRole('heading', { level: 1, name: 'Empty trail' })).toBeVisible()
-    await expect(page.getByRole('heading', { name: 'No items yet.' })).toBeVisible()
+    await expect(page.getByText('Add another item', { exact: true })).toBeVisible()
+    await expect(page.getByLabel('Find an item')).toBeVisible()
     await expect(page.getByRole('heading', { name: 'Planning' })).toHaveCount(0)
     await expect(page.getByRole('heading', { name: 'Checklist' })).toHaveCount(0)
     expect(state.detailRequests).toBe(1)
+    expect(state.availableGearRequests).toStrictEqual([{
+      page: 1,
+      search: ''
+    }])
   })
 
   test('should show cached lists while refreshing on return', async ({ context, page }) => {


### PR DESCRIPTION
## Summary

Turns the packing list detail into a focused item workspace 🎒✨ Users can search saved gear lazily, add a missing custom item, and remove entries without leaving the list 😎👍

- 🔎 Add debounced and paginated My gear discovery backed by an authenticated available-gear endpoint
- ➕ Support inventory-backed and custom entries with focused loading and error states
- 🗑️ Rework list entries into compact removable rows with pending-state protection
- ⌨️ Add Escape dismissal, focus restoration, clean focus rings, and stable icon sizing
- ✅ Expand query validation, endpoint coverage, and browser flows for add, remove, pagination, and keyboard behavior

## Motivation

The existing packing list detail could display items, but adding gear still needed a quick workflow inside the list itself 🧭 This keeps the common path lightweight while loading candidates only when the composer is opened, so the page stays calm and the server work stays lazy 🚀