### PR TITLE
Order category properties for catalog research

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,11 @@
+import { env } from 'node:process'
 import { defineConfig, devices, type ReporterDescription } from '@playwright/test'
 import { appBaseUrl } from './tests/playwright/constants.ts'
 
-const isCI = Boolean(process.env.CI)
+// Playwright forces color for the web server and workers, so inherited NO_COLOR only makes Node warn.
+delete env.NO_COLOR
+
+const isCI = Boolean(env.CI)
 
 const reporters: ReporterDescription[] = [
   ['html', { open: 'never' }]

--- a/server/api/equipment/categories/[categoryId]/properties/index.post.ts
+++ b/server/api/equipment/categories/[categoryId]/properties/index.post.ts
@@ -1,6 +1,13 @@
-import { and, eq } from 'drizzle-orm'
+import { and, DrizzleQueryError, eq, max } from 'drizzle-orm'
 import { createError, defineEventHandler, getValidatedRouterParams, isError, readValidatedBody, setResponseStatus } from 'h3'
-import { categoryProperties, contributions, equipmentCategories, propertyEnumOptions } from '#server/database/schema'
+import * as v from 'valibot'
+import {
+  categoryProperties,
+  categoryPropertyDisplayOrderConstraintName,
+  contributions,
+  equipmentCategories,
+  propertyEnumOptions
+} from '#server/database/schema'
 import { validateAdminUser } from '#server/utils/admin'
 import { createWebSocketClientFromEvent } from '#server/utils/config'
 
@@ -14,7 +21,35 @@ import {
   validateCategoryScopedParams
 } from '#server/utils/validation/schemas'
 
-export default defineEventHandler(async (event) => {
+interface CreatedCategoryPropertyEnumOption {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface CreatedCategoryPropertyResponse {
+  dataType: string;
+  enumOptions: CreatedCategoryPropertyEnumOption[] | undefined;
+  id: number;
+  name: string;
+  slug: string;
+  unit: string | null;
+}
+
+const displayOrderConflictCauseSchema = v.object({
+  code: v.literal('23505'),
+  constraint: v.literal(categoryPropertyDisplayOrderConstraintName)
+})
+
+function isDisplayOrderConflict(error: unknown): boolean {
+  if (error instanceof DrizzleQueryError === false) {
+    return false
+  }
+
+  return v.is(displayOrderConflictCauseSchema, error.cause)
+}
+
+export default defineEventHandler(async (event) : Promise<CreatedCategoryPropertyResponse> => {
   const userId = await validateAdminUser(event)
   const { categoryId } = await getValidatedRouterParams(event, validateCategoryScopedParams)
   const { dataType, enumOptions, name, slug, unit } = await readValidatedBody(event, validateCategoryPropertyMutationBody)
@@ -31,6 +66,7 @@ export default defineEventHandler(async (event) => {
           eq(equipmentCategories.id, categoryId)
         )
         .limit(1)
+        .for('update')
 
       if (existingCategory === undefined) {
         throw createError({ status: 404 })
@@ -56,11 +92,26 @@ export default defineEventHandler(async (event) => {
         })
       }
 
+      const maximumDisplayOrder = max(categoryProperties.displayOrder)
+
+      const [displayOrderRow] = await transaction
+        .select({
+          displayOrder: maximumDisplayOrder
+        })
+        .from(categoryProperties)
+        .where(
+          eq(categoryProperties.categoryId, categoryId)
+        )
+
+      const previousDisplayOrder = displayOrderRow?.displayOrder ?? -1
+      const displayOrder = previousDisplayOrder + 1
+
       const [newProperty] = await transaction
         .insert(categoryProperties)
         .values({
           categoryId,
           dataType,
+          displayOrder,
           name,
           slug,
           unit
@@ -121,6 +172,15 @@ export default defineEventHandler(async (event) => {
   } catch (error) {
     if (isError(error)) {
       throw error
+    }
+
+    const hasDisplayOrderConflict = isDisplayOrderConflict(error)
+
+    if (hasDisplayOrderConflict) {
+      throw createError({
+        status: 409,
+        message: 'Category property display order conflict'
+      })
     }
 
     throw createError({

--- a/server/api/equipment/categories/[slug].get.ts
+++ b/server/api/equipment/categories/[slug].get.ts
@@ -1,7 +1,29 @@
 import { createError, defineEventHandler, getValidatedRouterParams } from 'h3'
 import { validateCategoryDetailParams } from '#server/utils/validation/schemas'
 
-export default defineEventHandler(async (event) => {
+interface CategoryDetailEnumOption {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface CategoryDetailProperty {
+  dataType: string;
+  enumOptions?: CategoryDetailEnumOption[];
+  id: number;
+  name: string;
+  slug: string;
+  unit: string | null;
+}
+
+interface CategoryDetailResponse {
+  id: number;
+  name: string;
+  properties: CategoryDetailProperty[];
+  slug: string;
+}
+
+export default defineEventHandler(async (event) : Promise<CategoryDetailResponse> => {
   const { slug } = await getValidatedRouterParams(event, validateCategoryDetailParams)
 
   const category = await event.context.dbHttp.query.equipmentCategories.findFirst({
@@ -23,6 +45,11 @@ export default defineEventHandler(async (event) => {
           name: true,
           slug: true,
           unit: true
+        },
+
+        orderBy: {
+          displayOrder: 'asc',
+          id: 'asc'
         },
 
         with: {

--- a/server/api/equipment/categories/__tests__/properties.test.ts
+++ b/server/api/equipment/categories/__tests__/properties.test.ts
@@ -1,7 +1,9 @@
 import * as h3 from 'h3'
+import { DrizzleQueryError } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import deleteCategoryPropertyHandler from '#server/api/equipment/categories/[categoryId]/properties/[propertyId]/index.delete'
 import createCategoryPropertyHandler from '#server/api/equipment/categories/[categoryId]/properties/index.post'
+import { categoryPropertyDisplayOrderConstraintName } from '#server/database/schema'
 import type { CategoryPropertyBaseRecord, PropertyEnumOptionBaseRecord } from '#server/utils/equipment/base-records'
 import { createTestEvent } from '~~/test-utils/create-test-event'
 
@@ -23,6 +25,7 @@ interface MockWriteDb {
 interface SelectOperation {
   error?: Error;
   rows: unknown;
+  terminal?: 'for' | 'limit' | 'where';
 }
 
 interface InsertOperation {
@@ -84,6 +87,7 @@ vi.mock(import('#server/utils/config'), () => {
 })
 
 function createSelectMock(operations: SelectOperation[]) {
+  const forMocks: ReturnType<typeof vi.fn>[] = []
   const limitMocks: ReturnType<typeof vi.fn>[] = []
 
   const whereMock = vi.fn(() => {
@@ -93,9 +97,27 @@ function createSelectMock(operations: SelectOperation[]) {
       throw new Error('No select operation configured')
     }
 
+    if (operation.terminal === 'where') {
+      if (operation.error !== undefined) {
+        throw operation.error
+      }
+
+      return operation.rows
+    }
+
     const limitMock = vi.fn(() => {
       if (operation.error !== undefined) {
         throw operation.error
+      }
+
+      if (operation.terminal === 'for') {
+        const forMock = vi.fn(() => operation.rows)
+
+        forMocks.push(forMock)
+
+        return {
+          for: forMock
+        }
       }
 
       return operation.rows
@@ -121,6 +143,7 @@ function createSelectMock(operations: SelectOperation[]) {
   })
 
   return {
+    forMocks,
     selectMock
   }
 }
@@ -268,12 +291,18 @@ describe('category property handlers', () => {
         type: 'values'
       }])
 
-      const { selectMock } = createSelectMock([{
+      const { forMocks, selectMock } = createSelectMock([{
         rows: [{
           id: 5
-        }]
+        }],
+        terminal: 'for'
       }, {
         rows: []
+      }, {
+        rows: [{
+          displayOrder: 3
+        }],
+        terminal: 'where'
       }])
 
       const dbWrite = createDb({
@@ -298,10 +327,13 @@ describe('category property handlers', () => {
       expect(valuesMocks[0]).toHaveBeenCalledWith({
         categoryId: 5,
         dataType: 'enum',
+        displayOrder: 4,
         name: 'Fill Type',
         slug: 'fill-type',
         unit: undefined
       })
+
+      expect(forMocks[0]).toHaveBeenCalledWith('update')
 
       expect(valuesMocks[1]).toHaveBeenCalledWith([{
         name: 'Down',
@@ -355,9 +387,15 @@ describe('category property handlers', () => {
       const { selectMock } = createSelectMock([{
         rows: [{
           id: 5
-        }]
+        }],
+        terminal: 'for'
       }, {
         rows: []
+      }, {
+        rows: [{
+          displayOrder: null
+        }],
+        terminal: 'where'
       }])
 
       const dbWrite = createDb({
@@ -377,6 +415,15 @@ describe('category property handlers', () => {
       })
 
       expect(valuesMocks).toHaveLength(2)
+
+      expect(valuesMocks[0]).toHaveBeenCalledWith({
+        categoryId: 5,
+        dataType: 'number',
+        displayOrder: 0,
+        name: 'Weight',
+        slug: 'weight',
+        unit: 'g'
+      })
     })
 
     it('should return 404 when category does not exist', async () => {
@@ -390,7 +437,8 @@ describe('category property handlers', () => {
       const { insertMock } = createInsertMock([])
 
       const { selectMock } = createSelectMock([{
-        rows: []
+        rows: [],
+        terminal: 'for'
       }])
 
       const dbWrite = createDb({
@@ -423,7 +471,8 @@ describe('category property handlers', () => {
       const { selectMock } = createSelectMock([{
         rows: [{
           id: 5
-        }]
+        }],
+        terminal: 'for'
       }, {
         rows: [{
           id: 12
@@ -477,9 +526,15 @@ describe('category property handlers', () => {
       const { selectMock } = createSelectMock([{
         rows: [{
           id: 5
-        }]
+        }],
+        terminal: 'for'
       }, {
         rows: []
+      }, {
+        rows: [{
+          displayOrder: 0
+        }],
+        terminal: 'where'
       }])
 
       const dbWrite = createDb({
@@ -495,6 +550,57 @@ describe('category property handlers', () => {
       await expect(createCategoryPropertyHandler(event)).rejects.toMatchObject({
         message: 'Failed to create category property',
         statusCode: 500
+      })
+
+      expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return 409 when concurrent property creation conflicts on display order', async () => {
+      readValidatedBodyMock.mockResolvedValue({
+        dataType: 'number',
+        name: 'Weight',
+        slug: 'weight',
+        unit: 'g'
+      })
+
+      const postgresError = Object.assign(new Error('duplicate display order'), {
+        code: '23505',
+        constraint: categoryPropertyDisplayOrderConstraintName
+      })
+      const displayOrderConflict = new DrizzleQueryError('insert category property', [], postgresError)
+
+      const { insertMock } = createInsertMock([{
+        error: displayOrderConflict,
+        type: 'returning'
+      }])
+
+      const { selectMock } = createSelectMock([{
+        rows: [{
+          id: 5
+        }],
+        terminal: 'for'
+      }, {
+        rows: []
+      }, {
+        rows: [{
+          displayOrder: 0
+        }],
+        terminal: 'where'
+      }])
+
+      const dbWrite = createDb({
+        delete: vi.fn(),
+        insert: insertMock,
+        select: selectMock
+      })
+
+      createWebSocketClientMock.mockReturnValue(dbWrite)
+
+      const event = createTestEvent({})
+
+      await expect(createCategoryPropertyHandler(event)).rejects.toMatchObject({
+        message: 'Category property display order conflict',
+        statusCode: 409
       })
 
       expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)

--- a/server/api/equipment/categories/__tests__/reads.test.ts
+++ b/server/api/equipment/categories/__tests__/reads.test.ts
@@ -46,8 +46,19 @@ interface CategoryDetail {
   slug: string;
 }
 
+interface CategoryDetailQuery {
+  with: {
+    properties: {
+      orderBy: {
+        displayOrder: 'asc';
+        id: 'asc';
+      };
+    };
+  };
+}
+
 function createDetailDb(category?: CategoryDetail) {
-  const findFirstMock = vi.fn(() => category)
+  const findFirstMock = vi.fn((_query: CategoryDetailQuery) => category)
 
   return {
     dbHttp: {
@@ -135,6 +146,12 @@ describe('get /api/equipment/categories/[slug]', () => {
     })
 
     expect(findFirstMock).toHaveBeenCalledTimes(1)
+    const query = findFirstMock.mock.calls[0]?.[0]
+
+    expect(query?.with.properties.orderBy).toStrictEqual({
+      displayOrder: 'asc',
+      id: 'asc'
+    })
   })
 
   it('should return 400 when route params validation fails', async () => {

--- a/server/database/__tests__/migration.test.ts
+++ b/server/database/__tests__/migration.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const migrationUrl = new URL('../migrations/20260711222621_stormy_captain_marvel/migration.sql', import.meta.url)
+const migrationSql = readFileSync(migrationUrl, 'utf8')
+
+describe('category property display order migration', () => {
+  it('should backfill a zero-based order before making the column required', () => {
+    const addColumnStatement = 'ALTER TABLE "category_properties" ADD COLUMN "displayOrder" integer;'
+    const setNotNullStatement = 'ALTER TABLE "category_properties" ALTER COLUMN "displayOrder" SET NOT NULL;'
+    const uniqueConstraintStatement = 'CONSTRAINT "category_properties_categoryId_displayOrder_unique"'
+    const addColumnPosition = migrationSql.indexOf(addColumnStatement)
+    const backfillPosition = migrationSql.indexOf('WITH ordered_properties AS')
+    const setNotNullPosition = migrationSql.indexOf(setNotNullStatement)
+    const uniqueConstraintPosition = migrationSql.indexOf(uniqueConstraintStatement)
+
+    expect(addColumnPosition).toBeGreaterThanOrEqual(0)
+    expect(backfillPosition).toBeGreaterThan(addColumnPosition)
+    expect(setNotNullPosition).toBeGreaterThan(backfillPosition)
+    expect(uniqueConstraintPosition).toBeGreaterThan(setNotNullPosition)
+    expect(migrationSql).toMatch(/row_number\(\) OVER \(PARTITION BY "categoryId" ORDER BY "id"\) - 1\)::integer/u)
+  })
+
+  it('should enforce unique order and add the confirmed research indexes', () => {
+    expect(migrationSql).toContain(
+      'CONSTRAINT "category_properties_categoryId_displayOrder_unique" UNIQUE("categoryId","displayOrder")'
+    )
+
+    expect(migrationSql).toContain(
+      'INDEX "equipment_items_approved_category_brand_index" ON "equipment_items" ("categoryId","brandId") WHERE "status" = \'approved\''
+    )
+
+    expect(migrationSql).toContain(
+      'INDEX "item_property_values_property_number_index" ON "item_property_values" ("propertyId","valueNumber","itemId")'
+    )
+
+    expect(migrationSql).toContain(
+      'INDEX "item_property_values_property_text_index" ON "item_property_values" ("propertyId","valueText","itemId")'
+    )
+
+    expect(migrationSql).toContain(
+      'INDEX "item_property_values_property_boolean_index" ON "item_property_values" ("propertyId","valueBoolean","itemId")'
+    )
+  })
+})

--- a/server/database/__tests__/schema.test.ts
+++ b/server/database/__tests__/schema.test.ts
@@ -1,7 +1,28 @@
 import { eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/neon-http'
+import { getTableConfig } from 'drizzle-orm/pg-core'
 import { describe, expect, it } from 'vitest'
 import * as schema from '../schema'
+
+function getIndexColumnNames(tableIndex: ReturnType<typeof getTableConfig>['indexes'][number]) {
+  return tableIndex.config.columns.map((column) => {
+    if ('name' in column) {
+      return column.name
+    }
+
+    throw new Error('Expected an indexed table column')
+  })
+}
+
+function getRequiredIndex(tableConfig: ReturnType<typeof getTableConfig>, indexName: string) {
+  const tableIndex = tableConfig.indexes.find((index) => index.config.name === indexName)
+
+  if (tableIndex === undefined) {
+    throw new Error(`Missing index ${indexName}`)
+  }
+
+  return tableIndex
+}
 
 describe('equipmentItems updatedAt', () => {
   it('should append updatedAt = now() to update queries without touching createdAt', () => {
@@ -23,5 +44,51 @@ describe('equipmentItems updatedAt', () => {
       'Updated item name',
       '0195f2d0-6f5a-7f20-8000-123456789abc'
     ])
+  })
+})
+
+describe('equipment catalog research schema', () => {
+  it('should require a unique display order within each category', () => {
+    const tableConfig = getTableConfig(schema.categoryProperties)
+    const displayOrderColumn = tableConfig.columns.find((column) => column.name === 'displayOrder')
+    const displayOrderConstraint = tableConfig.uniqueConstraints.find(
+      (constraint) => constraint.getName() === schema.categoryPropertyDisplayOrderConstraintName
+    )
+
+    expect(displayOrderColumn?.notNull).toBe(true)
+    expect(displayOrderConstraint?.columns.map((column) => column.name)).toStrictEqual([
+      'categoryId',
+      'displayOrder'
+    ])
+  })
+
+  it('should index each typed property value by property and item', () => {
+    const tableConfig = getTableConfig(schema.itemPropertyValues)
+    const indexes = tableConfig.indexes.map((tableIndex) => {
+      return {
+        columns: getIndexColumnNames(tableIndex),
+        name: tableIndex.config.name
+      }
+    })
+
+    expect(indexes).toStrictEqual(expect.arrayContaining([{
+      columns: ['propertyId', 'valueNumber', 'itemId'],
+      name: 'item_property_values_property_number_index'
+    }, {
+      columns: ['propertyId', 'valueText', 'itemId'],
+      name: 'item_property_values_property_text_index'
+    }, {
+      columns: ['propertyId', 'valueBoolean', 'itemId'],
+      name: 'item_property_values_property_boolean_index'
+    }]))
+  })
+
+  it('should index approved items by category and brand', () => {
+    const tableConfig = getTableConfig(schema.equipmentItems)
+    const approvedItemIndex = getRequiredIndex(tableConfig, 'equipment_items_approved_category_brand_index')
+    const indexColumns = getIndexColumnNames(approvedItemIndex)
+
+    expect(indexColumns).toStrictEqual(['categoryId', 'brandId'])
+    expect(approvedItemIndex.config.where).toBeDefined()
   })
 })

--- a/server/database/migrations/20260711222621_stormy_captain_marvel/migration.sql
+++ b/server/database/migrations/20260711222621_stormy_captain_marvel/migration.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "category_properties" ADD COLUMN "displayOrder" integer;--> statement-breakpoint
+WITH ordered_properties AS (
+	SELECT
+		"id",
+		(row_number() OVER (PARTITION BY "categoryId" ORDER BY "id") - 1)::integer AS "displayOrder"
+	FROM "category_properties"
+)
+UPDATE "category_properties" AS property
+SET "displayOrder" = ordered_properties."displayOrder"
+FROM ordered_properties
+WHERE property."id" = ordered_properties."id";--> statement-breakpoint
+ALTER TABLE "category_properties" ALTER COLUMN "displayOrder" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "category_properties" ADD CONSTRAINT "category_properties_categoryId_displayOrder_unique" UNIQUE("categoryId","displayOrder");--> statement-breakpoint
+CREATE INDEX "equipment_items_approved_category_brand_index" ON "equipment_items" ("categoryId","brandId") WHERE "status" = 'approved';--> statement-breakpoint
+CREATE INDEX "item_property_values_property_number_index" ON "item_property_values" ("propertyId","valueNumber","itemId");--> statement-breakpoint
+CREATE INDEX "item_property_values_property_text_index" ON "item_property_values" ("propertyId","valueText","itemId");--> statement-breakpoint
+CREATE INDEX "item_property_values_property_boolean_index" ON "item_property_values" ("propertyId","valueBoolean","itemId");

--- a/server/database/migrations/20260711222621_stormy_captain_marvel/snapshot.json
+++ b/server/database/migrations/20260711222621_stormy_captain_marvel/snapshot.json
@@ -1,0 +1,1718 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "225ea64b-5d2e-4c95-bd35-181f480075b4",
+  "prevIds": [
+    "cafdd421-b296-4a33-a3db-cd1725eb0f7d"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "brands",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "category_properties",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "contributions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "equipment_categories",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "equipment_groups",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "equipment_items",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "item_property_values",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_providers",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "packing_list_entries",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "packing_lists",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "property_enum_options",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_equipment",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "brands"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "brands"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "brands"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "brands"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "categoryId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataType",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "displayOrder",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "unit",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "targetId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_categories"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_categories"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_categories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_categories"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_groups"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_groups"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_groups"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_groups"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "categoryId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "brandId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'approved'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "createdBy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "itemId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "propertyId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valueText",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "numeric",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valueNumber",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valueBoolean",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "providerId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "accountId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_providers"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_providers"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_providers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_providers"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "packingListId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "customName",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userEquipmentId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "isPacked",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "propertyId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "itemId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "isAdmin",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "categoryId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "brandId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"status\" = 'approved'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "equipment_items_approved_category_brand_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "propertyId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "valueNumber",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "itemId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "item_property_values_property_number_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "propertyId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "valueText",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "itemId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "item_property_values_property_text_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "propertyId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "valueBoolean",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "itemId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "item_property_values_property_boolean_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "categoryId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_categories",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "category_properties_categoryId_equipment_categories_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "contributions_userId_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "categoryId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_categories",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "RESTRICT",
+      "name": "equipment_items_categoryId_equipment_categories_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "brandId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "brands",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "RESTRICT",
+      "name": "equipment_items_brandId_brands_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "createdBy"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "equipment_items_createdBy_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "itemId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_items",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "item_property_values_itemId_equipment_items_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "propertyId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "category_properties",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "item_property_values_propertyId_category_properties_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "oauth_accounts_userId_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "providerId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "oauth_providers",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "oauth_accounts_providerId_oauth_providers_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "packingListId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "packing_lists",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "packing_list_entries_packingListId_packing_lists_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userEquipmentId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user_equipment",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "RESTRICT",
+      "name": "packing_list_entries_userEquipmentId_user_equipment_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "packing_lists_userId_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "propertyId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "category_properties",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "property_enum_options_propertyId_category_properties_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "user_equipment_userId_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "itemId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_items",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "user_equipment_itemId_equipment_items_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "brands_pkey",
+      "schema": "public",
+      "table": "brands",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "category_properties_pkey",
+      "schema": "public",
+      "table": "category_properties",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "contributions_pkey",
+      "schema": "public",
+      "table": "contributions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "equipment_categories_pkey",
+      "schema": "public",
+      "table": "equipment_categories",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "equipment_groups_pkey",
+      "schema": "public",
+      "table": "equipment_groups",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "equipment_items_pkey",
+      "schema": "public",
+      "table": "equipment_items",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "item_property_values_pkey",
+      "schema": "public",
+      "table": "item_property_values",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_accounts_pkey",
+      "schema": "public",
+      "table": "oauth_accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_providers_pkey",
+      "schema": "public",
+      "table": "oauth_providers",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "packing_list_entries_pkey",
+      "schema": "public",
+      "table": "packing_list_entries",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "packing_lists_pkey",
+      "schema": "public",
+      "table": "packing_lists",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "property_enum_options_pkey",
+      "schema": "public",
+      "table": "property_enum_options",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_equipment_pkey",
+      "schema": "public",
+      "table": "user_equipment",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "categoryId",
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "category_properties_categoryId_slug_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "categoryId",
+        "displayOrder"
+      ],
+      "nullsNotDistinct": false,
+      "name": "category_properties_categoryId_displayOrder_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "itemId",
+        "propertyId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "item_property_values_itemId_propertyId_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "providerId",
+        "accountId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_accounts_providerId_accountId_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "packingListId",
+        "userEquipmentId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "packing_list_entries_packingListId_userEquipmentId_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "propertyId",
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "property_enum_options_propertyId_slug_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId",
+        "itemId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_equipment_userId_itemId_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "brands_name_key",
+      "schema": "public",
+      "table": "brands",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "brands_slug_key",
+      "schema": "public",
+      "table": "brands",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "equipment_categories_slug_key",
+      "schema": "public",
+      "table": "equipment_categories",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "equipment_groups_slug_key",
+      "schema": "public",
+      "table": "equipment_groups",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "type"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_providers_type_key",
+      "schema": "public",
+      "table": "oauth_providers",
+      "entityType": "uniques"
+    },
+    {
+      "value": "((\"packing_list_entries\".\"customName\" IS NOT NULL) <> (\"packing_list_entries\".\"userEquipmentId\" IS NOT NULL))",
+      "name": "packing_list_entries_source_check",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "packing_list_entries"
+    }
+  ],
+  "renames": []
+}

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -1,7 +1,7 @@
 // oxlint-disable max-lines
 // oxlint-disable import/no-relative-parent-imports
 import { sql } from 'drizzle-orm'
-import { integer, serial, timestamp, boolean, varchar, unique, uuid, numeric, jsonb, pgTable, text, check } from 'drizzle-orm/pg-core'
+import { boolean, check, index, integer, jsonb, numeric, pgTable, serial, text, timestamp, unique, uuid, varchar } from 'drizzle-orm/pg-core'
 // FIXME: drizzle-kit can't handle #shared/constants, so we have to import it with a relative path
 import { limits } from '../../shared/constants'
 
@@ -251,7 +251,13 @@ const equipmentItems = pgTable('equipment_items', {
     .notNull()
     .defaultNow()
     .$onUpdate(() => sql`now()`)
-})
+}, (table) => [
+  index('equipment_items_approved_category_brand_index')
+    .on(table.categoryId, table.brandId)
+    .where(sql`${table.status} = 'approved'`)
+])
+
+const categoryPropertyDisplayOrderConstraintName = 'category_properties_categoryId_displayOrder_unique'
 
 /**
  * Property definitions per category (EAV schema layer).
@@ -283,6 +289,10 @@ const categoryProperties = pgTable('category_properties', {
     varchar({ length: 16 })
     .notNull(),
 
+  displayOrder:
+    integer()
+    .notNull(),
+
   unit:
     varchar({ length: limits.maxCategoryPropertyUnitLength }),
 
@@ -293,7 +303,8 @@ const categoryProperties = pgTable('category_properties', {
     .notNull()
     .defaultNow()
 }, (table) => [
-  unique().on(table.categoryId, table.slug)
+  unique().on(table.categoryId, table.slug),
+  unique(categoryPropertyDisplayOrderConstraintName).on(table.categoryId, table.displayOrder)
 ])
 
 /**
@@ -360,7 +371,10 @@ const itemPropertyValues = pgTable('item_property_values', {
   valueBoolean:
     boolean()
 }, (table) => [
-  unique().on(table.itemId, table.propertyId)
+  unique().on(table.itemId, table.propertyId),
+  index('item_property_values_property_number_index').on(table.propertyId, table.valueNumber, table.itemId),
+  index('item_property_values_property_text_index').on(table.propertyId, table.valueText, table.itemId),
+  index('item_property_values_property_boolean_index').on(table.propertyId, table.valueBoolean, table.itemId)
 ])
 
 // ─── User data ──────────────────────────────────────────────────────
@@ -552,5 +566,6 @@ export {
   userEquipment,
   packingLists,
   packingListEntries,
-  contributions
+  contributions,
+  categoryPropertyDisplayOrderConstraintName
 }

--- a/tools/__tests__/seed-catalog.test.ts
+++ b/tools/__tests__/seed-catalog.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { buildCategoryPropertySeedRows } from '../seed-catalog'
+import { propertyDefinitionsByCategorySlug } from '../seed-data'
+
+describe(buildCategoryPropertySeedRows, () => {
+  it('should derive zero-based display order from each category definition array', () => {
+    const categorySlugs = Object.keys(propertyDefinitionsByCategorySlug)
+    const categoryIdBySlug = new Map(categorySlugs.map((categorySlug, index) => [categorySlug, index + 1]))
+    const rows = buildCategoryPropertySeedRows(categoryIdBySlug)
+
+    for (const [categorySlug, definitions] of Object.entries(propertyDefinitionsByCategorySlug)) {
+      const categoryId = categoryIdBySlug.get(categorySlug)
+      const categoryRows = rows.filter((row) => row.categoryId === categoryId)
+      const orderedProperties = categoryRows.map((row) => {
+        return {
+          displayOrder: row.displayOrder,
+          slug: row.slug
+        }
+      })
+
+      const expectedProperties = definitions.map((definition, displayOrder) => {
+        return {
+          displayOrder,
+          slug: definition.slug
+        }
+      })
+
+      expect(orderedProperties).toStrictEqual(expectedProperties)
+    }
+  })
+})

--- a/tools/seed-catalog.ts
+++ b/tools/seed-catalog.ts
@@ -69,6 +69,28 @@ function getRequiredMapValue<ValueType>(
   return value
 }
 
+/** Maps ordered property definitions to the rows inserted by the catalog seed. */
+function buildCategoryPropertySeedRows(categoryIdBySlug: Map<string, number>) {
+  return Object.entries(propertyDefinitionsByCategorySlug).flatMap(([categorySlug, properties]) => {
+    const categoryId = getRequiredMapValue(
+      categoryIdBySlug,
+      categorySlug,
+      `Missing category ${categorySlug}`
+    )
+
+    return properties.map((property, displayOrder) => {
+      return {
+        categoryId,
+        dataType: property.dataType,
+        displayOrder,
+        name: property.name,
+        slug: property.slug,
+        unit: property.unit ?? null
+      }
+    })
+  })
+}
+
 async function seedCatalog(db: Database) {
   assertSampleItemCoverage()
 
@@ -199,23 +221,7 @@ async function seedCatalog(db: Database) {
       brandsList.map((brand) => [brand.slug, brand.id])
     )
 
-    const propertyRows = Object.entries(propertyDefinitionsByCategorySlug).flatMap(([categorySlug, properties]) => {
-      const categoryId = getRequiredMapValue(
-        categoryIdBySlug,
-        categorySlug,
-        `Missing category ${categorySlug}`
-      )
-
-      return properties.map((property) => {
-        return {
-          categoryId,
-          dataType: property.dataType,
-          name: property.name,
-          slug: property.slug,
-          unit: property.unit ?? null
-        }
-      })
-    })
+    const propertyRows = buildCategoryPropertySeedRows(categoryIdBySlug)
 
     await tx.insert(categoryProperties).values(propertyRows)
 
@@ -334,5 +340,6 @@ async function seedCatalog(db: Database) {
 }
 
 export {
+  buildCategoryPropertySeedRows,
   seedCatalog
 }


### PR DESCRIPTION
## Summary

Gives catalog properties one stable order from seed to API response 🧭💾 No more relying on insertion order while the research foundation grows 😎🔥

- 🗂️ Add zero-based per-category display order with a safe existing-data backfill
- 🔒 Serialize property appends and return HTTP 409 for the exact ordering conflict
- ⚡ Add approved-item and typed EAV indexes for catalog research lookups
- 🌱 Preserve property definition order in catalog seed data
- 🧪 Cover schema, migration SQL, API ordering, concurrency protection, and seed behavior

## Motivation

Category summaries and comparisons need deterministic property ordering, while filter research needs the current EAV model to stay queryable without a redesign 🧠🛠️ This change adds that foundation while keeping API payloads focused and stable 💪😎

## Related Issues

Fixes #678
Part of #677