### PR TITLE
Expand catalog item query contract

### DIFF
--- a/app/components/gear-library/GearLibraryItemSummaryCard.vue
+++ b/app/components/gear-library/GearLibraryItemSummaryCard.vue
@@ -1,14 +1,8 @@
 <template>
   <PerdCard :class="$style.component">
-    <div :class="$style.header">
-      <p :class="$style.eyebrow">
-        {{ brandName }}
-      </p>
-
-      <PerdPill :tone="statusTone">
-        {{ statusText }}
-      </PerdPill>
-    </div>
+    <p :class="$style.eyebrow">
+      {{ brandName }}
+    </p>
 
     <dl :class="$style.metadataList">
       <div :class="$style.metadataItem">
@@ -30,44 +24,17 @@
           {{ categoryName }}
         </dd>
       </div>
-
-      <div :class="$style.metadataItem">
-        <dt :class="$style.metadataLabel">
-          Status
-        </dt>
-
-        <dd :class="$style.metadataValue">
-          {{ statusText }}
-        </dd>
-      </div>
     </dl>
   </PerdCard>
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
-  import PerdPill, { type PerdPillTone } from '~/components/PerdPill.vue'
-
   interface Props {
     brandName: string;
     categoryName: string;
-    statusClass: string;
-    statusText: string;
   }
 
-  const props = defineProps<Props>()
-
-  const statusTone = computed<PerdPillTone>(() => {
-    if (props.statusClass === 'approved') {
-      return 'success'
-    }
-
-    if (props.statusClass === 'rejected') {
-      return 'danger'
-    }
-
-    return 'warning'
-  })
+  defineProps<Props>()
 </script>
 
 <style module>
@@ -75,14 +42,6 @@
     display: grid;
     gap: var(--spacing-24);
     container-type: inline-size;
-  }
-
-  .header {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    gap: var(--spacing-12);
-    align-items: center;
   }
 
   .eyebrow {
@@ -98,7 +57,7 @@
     gap: var(--spacing-12);
 
     @container (inline-size >= 40rem) {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 

--- a/app/pages/gear-library/[id].vue
+++ b/app/pages/gear-library/[id].vue
@@ -30,8 +30,6 @@
             <GearLibraryItemSummaryCard
               :brand-name="itemResponse.brand.name"
               :category-name="itemResponse.category.name"
-              :status-class="statusClass"
-              :status-text="statusText"
             />
           </div>
 
@@ -108,8 +106,7 @@
         createdAt: '',
         id: '',
         name: '',
-        properties: [],
-        status: ''
+        properties: []
       }
     }
   })
@@ -128,43 +125,25 @@
   const isMyGearLoading = computed(() => myGearStatus.value === 'pending')
   const hasMyGearError = computed(() => myGearError.value !== undefined)
 
-  function formatStatus(status: string) {
-    if (status === '') {
-      return 'Unknown'
-    }
-
-    return `${status.slice(0, 1).toUpperCase()}${status.slice(1)}`
-  }
-
-  function formatPropertyValue(property: ItemProperty) {
+  function formatPropertyValue(property: ItemProperty): string {
     if (property.value === null) {
       return 'Not set'
     }
 
-    if (property.dataType === 'boolean') {
-      return property.value === 'true' ? 'Yes' : 'No'
+    if (typeof property.value === 'boolean') {
+      return property.value ? 'Yes' : 'No'
     }
+
+    const value = String(property.value)
 
     if (property.unit !== null && property.unit !== '') {
-      return `${property.value} ${property.unit}`
+      return `${value} ${property.unit}`
     }
 
-    return property.value
+    return value
   }
 
   const pageTitle = computed(() => itemResponse.value.name === '' ? 'Gear item' : itemResponse.value.name)
-  const statusText = computed(() => formatStatus(itemResponse.value.status))
-  const statusClass = computed(() => {
-    if (itemResponse.value.status === 'approved') {
-      return 'approved'
-    }
-
-    if (itemResponse.value.status === 'rejected') {
-      return 'rejected'
-    }
-
-    return 'pending'
-  })
   const ownedMyGearRow = computed(() => myGearResponse.value.find((myGearRow) => myGearRow.item.id === itemResponse.value.id))
   const isOwned = computed(() => ownedMyGearRow.value !== undefined)
   const isMyGearActionLoading = computed(() => isMyGearLoading.value || isMyGearPending.value)

--- a/app/types/equipment.ts
+++ b/app/types/equipment.ts
@@ -12,6 +12,7 @@ interface GearLibraryListItem {
   category: GearLibraryEntitySummary;
   id: string;
   name: string;
+  properties: ItemProperty[];
 }
 
 interface GearLibraryListItemView {
@@ -29,12 +30,15 @@ interface GearLibraryItemsResponse {
   total: number;
 }
 
+type EquipmentPropertyDataType = 'boolean' | 'enum' | 'number' | 'text'
+type EquipmentPropertyValue = string | number | boolean | null
+
 interface ItemProperty {
-  dataType: string;
+  dataType: EquipmentPropertyDataType;
   name: string;
   slug: string;
   unit: string | null;
-  value: string | null;
+  value: EquipmentPropertyValue;
 }
 
 interface ItemDetailResponse {
@@ -44,7 +48,6 @@ interface ItemDetailResponse {
   id: string;
   name: string;
   properties: ItemProperty[];
-  status: string;
 }
 
 interface ItemDisplayProperty extends ItemProperty {
@@ -75,6 +78,8 @@ interface MyGearRecordView {
 }
 
 export type {
+  EquipmentPropertyDataType,
+  EquipmentPropertyValue,
   GearLibraryEntityDetail,
   GearLibraryEntitySummary,
   GearLibraryItemsResponse,

--- a/server/api/equipment/items/[id].get.ts
+++ b/server/api/equipment/items/[id].get.ts
@@ -1,4 +1,10 @@
 import { createError, defineEventHandler, getValidatedRouterParams } from 'h3'
+import {
+  getEquipmentPropertyDataType,
+  normalizeEquipmentPropertyValue,
+  type EquipmentPropertyDataType,
+  type EquipmentPropertyValue
+} from '#server/utils/equipment/property-values'
 import { validateItemDetailParams } from '#server/utils/validation/schemas'
 
 interface ItemDetailBrand {
@@ -14,11 +20,11 @@ interface ItemDetailCategory {
 }
 
 interface ItemProperty {
-  dataType: string;
+  dataType: EquipmentPropertyDataType;
   name: string;
   slug: string;
   unit: string | null;
-  value: string | null;
+  value: EquipmentPropertyValue;
 }
 
 interface ItemDetailResponse {
@@ -28,7 +34,6 @@ interface ItemDetailResponse {
   id: string;
   name: string;
   properties: ItemProperty[];
-  status: string;
 }
 
 export default defineEventHandler(async (event) : Promise<ItemDetailResponse> => {
@@ -38,12 +43,12 @@ export default defineEventHandler(async (event) : Promise<ItemDetailResponse> =>
     columns: {
       createdAt: true,
       id: true,
-      name: true,
-      status: true
+      name: true
     },
 
     where: {
-      id
+      id,
+      status: 'approved'
     },
 
     with: {
@@ -74,6 +79,8 @@ export default defineEventHandler(async (event) : Promise<ItemDetailResponse> =>
           property: {
             columns: {
               dataType: true,
+              displayOrder: true,
+              id: true,
               name: true,
               slug: true,
               unit: true
@@ -96,22 +103,47 @@ export default defineEventHandler(async (event) : Promise<ItemDetailResponse> =>
   }
 
   const properties: ItemProperty[] = []
+  const propertyValues = [...item.propertyValues]
 
-  // Property values live in type-specific columns, so the response normalizes them into one `value` field.
-  for (const propertyValue of item.propertyValues) {
+  propertyValues.sort((left, right) => {
+    const leftProperty = left.property
+    const rightProperty = right.property
+
+    if (leftProperty === null && rightProperty === null) {
+      return 0
+    }
+
+    if (leftProperty === null) {
+      return 1
+    }
+
+    if (rightProperty === null) {
+      return -1
+    }
+
+    const displayOrderDifference = leftProperty.displayOrder - rightProperty.displayOrder
+
+    if (displayOrderDifference !== 0) {
+      return displayOrderDifference
+    }
+
+    return leftProperty.id - rightProperty.id
+  })
+
+  for (const propertyValue of propertyValues) {
     const { property } = propertyValue
 
     if (property !== null) {
-      let value: string | null = propertyValue.valueText
-
-      if (property.dataType === 'number') {
-        value = propertyValue.valueNumber
-      } else if (property.dataType === 'boolean') {
-        value = String(propertyValue.valueBoolean)
-      }
+      const dataType = getEquipmentPropertyDataType(property.dataType)
+      const value = normalizeEquipmentPropertyValue({
+        dataType,
+        valueBoolean: propertyValue.valueBoolean,
+        valueNumber: propertyValue.valueNumber,
+        valueText: propertyValue.valueText
+      })
 
       properties.push({
-        dataType: property.dataType,
+        dataType,
         name: property.name,
         slug: property.slug,
         unit: property.unit,
@@ -121,12 +153,21 @@ export default defineEventHandler(async (event) : Promise<ItemDetailResponse> =>
   }
 
   return {
-    brand: item.brand,
-    category: item.category,
+    brand: {
+      id: item.brand.id,
+      name: item.brand.name,
+      slug: item.brand.slug
+    },
+
+    category: {
+      id: item.category.id,
+      name: item.category.name,
+      slug: item.category.slug
+    },
+
     createdAt: item.createdAt,
     id: item.id,
     name: item.name,
-    properties,
-    status: item.status
+    properties
   }
 })

--- a/server/api/equipment/items/__tests__/list.test.ts
+++ b/server/api/equipment/items/__tests__/list.test.ts
@@ -1,0 +1,399 @@
+import * as h3 from 'h3'
+import type { SQL } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import listItemsHandler from '#server/api/equipment/items/index.get'
+import type { validateItemsListQuery } from '#server/utils/validation/schemas'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+type ItemsListQuery = ReturnType<typeof validateItemsListQuery>
+
+const { getValidatedQueryMock } = vi.hoisted(() => {
+  return {
+    getValidatedQueryMock: vi.fn<typeof h3.getValidatedQuery>()
+  }
+})
+
+// @ts-expect-error -- Vitest's import-based module mock typing rejects this partial h3 mock.
+vi.mock(import('h3'), async () => {
+  const actual = await vi.importActual<typeof h3>('h3')
+
+  return {
+    ...actual,
+
+    async getValidatedQuery(...args: Parameters<typeof h3.getValidatedQuery>) {
+      return getValidatedQueryMock(...args)
+    }
+  }
+})
+
+function createQuery(overrides: Partial<ItemsListQuery> = {}) : ItemsListQuery {
+  return {
+    booleanFilter: [],
+    brandSlug: [],
+    categorySlug: undefined,
+    direction: 'asc',
+    enumFilter: [],
+    limit: 20,
+    numberFilter: [],
+    page: 1,
+    search: '',
+    sort: 'name',
+    ...overrides
+  }
+}
+
+function createCategoryMetadata() {
+  return {
+    id: 2,
+
+    properties: [{
+      dataType: 'number',
+      enumOptions: [],
+      id: 10,
+      slug: 'weight'
+    }, {
+      dataType: 'enum',
+      enumOptions: [{ slug: 'canister' }, { slug: 'alcohol' }],
+      id: 11,
+      slug: 'fuel'
+    }, {
+      dataType: 'boolean',
+      enumOptions: [],
+      id: 12,
+      slug: 'piezo'
+    }]
+  }
+}
+
+function createJoinChain(terminal: object) {
+  const categoryJoinMock = vi.fn(() => terminal)
+  const brandJoinMock = vi.fn(() => {
+    return { innerJoin: categoryJoinMock }
+  })
+
+  return vi.fn(() => {
+    return { innerJoin: brandJoinMock }
+  })
+}
+
+function createListDb({
+  categoryMetadata,
+  definitions = [],
+  items = [],
+  total = 0,
+  values = []
+}: {
+  categoryMetadata?: unknown;
+  definitions?: unknown[];
+  items?: unknown[];
+  total?: number;
+  values?: unknown[];
+} = {}) {
+  const itemsOffsetMock = vi.fn(() => items)
+  const itemsLimitMock = vi.fn(() => {
+    return { offset: itemsOffsetMock }
+  })
+  const itemsOrderByMock = vi.fn((..._conditions: SQL[]) => {
+    return { limit: itemsLimitMock }
+  })
+  const itemsWhereMock = vi.fn((_condition: SQL | undefined) => {
+    return { orderBy: itemsOrderByMock }
+  })
+  const itemsLeftJoinMock = vi.fn((_table: unknown, _condition: SQL | undefined) => {
+    return { where: itemsWhereMock }
+  })
+  const itemsFromMock = createJoinChain({ leftJoin: itemsLeftJoinMock, where: itemsWhereMock })
+  const countWhereMock = vi.fn((_condition: SQL | undefined) => [{ total }])
+  const countFromMock = createJoinChain({ where: countWhereMock })
+  const definitionsOrderByMock = vi.fn((..._conditions: SQL[]) => definitions)
+  const definitionsWhereMock = vi.fn(() => {
+    return { orderBy: definitionsOrderByMock }
+  })
+  const definitionsFromMock = vi.fn(() => {
+    return { where: definitionsWhereMock }
+  })
+  const valuesWhereMock = vi.fn(() => values)
+  const valuesFromMock = vi.fn(() => {
+    return { where: valuesWhereMock }
+  })
+  const findFirstMock = vi.fn(() => categoryMetadata)
+  const selectMock = vi.fn((selection: Record<string, unknown>) => {
+    if ('total' in selection) {
+      return { from: countFromMock }
+    }
+
+    if ('displayOrder' in selection) {
+      return { from: definitionsFromMock }
+    }
+
+    if ('itemId' in selection) {
+      return { from: valuesFromMock }
+    }
+
+    return { from: itemsFromMock }
+  })
+
+  return {
+    dbHttp: {
+      query: {
+        equipmentCategories: {
+          findFirst: findFirstMock
+        }
+      },
+      select: selectMock
+    },
+    countWhereMock,
+    definitionsOrderByMock,
+    findFirstMock,
+    itemsLeftJoinMock,
+    itemsLimitMock,
+    itemsOffsetMock,
+    itemsOrderByMock,
+    itemsWhereMock,
+    selectMock
+  }
+}
+
+function compileSql(value: SQL | undefined) {
+  if (value === undefined) {
+    throw new Error('Expected a defined SQL fragment')
+  }
+
+  const dialect = new PgDialect()
+
+  return dialect.sqlToQuery(value)
+}
+
+function compactSql(value: SQL | undefined) {
+  return compileSql(value).sql.replaceAll(/\s+/gu, ' ').trim()
+}
+
+describe('get /api/equipment/items', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getValidatedQueryMock.mockResolvedValue(createQuery())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should return paginated rows enriched with three ordered typed properties', async () => {
+    const id = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+    const secondId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d8'
+    const itemRows = [{
+      categoryId: 2,
+      id,
+      name: 'PocketRocket Deluxe',
+      brand: { name: 'MSR', slug: 'msr' },
+      category: { name: 'Stoves', slug: 'stoves' }
+    }, {
+      categoryId: 3,
+      id: secondId,
+      name: 'Solo Pot',
+      brand: { name: 'Solo', slug: 'solo' },
+      category: { name: 'Cookware', slug: 'cookware' }
+    }]
+    const definitions = [
+      { categoryId: 2, dataType: 'number', displayOrder: 0, id: 10, name: 'Weight', slug: 'weight', unit: 'g' },
+      { categoryId: 2, dataType: 'boolean', displayOrder: 1, id: 12, name: 'Piezo', slug: 'piezo', unit: null },
+      { categoryId: 2, dataType: 'enum', displayOrder: 2, id: 11, name: 'Fuel', slug: 'fuel', unit: null },
+      { categoryId: 2, dataType: 'text', displayOrder: 3, id: 13, name: 'Notes', slug: 'notes', unit: null },
+      { categoryId: 3, dataType: 'number', displayOrder: 0, id: 20, name: 'Volume', slug: 'volume', unit: 'ml' }
+    ]
+    const values = [
+      { itemId: id, propertyId: 10, valueBoolean: null, valueNumber: '83', valueText: null },
+      { itemId: id, propertyId: 12, valueBoolean: true, valueNumber: null, valueText: null }
+    ]
+    const db = createListDb({ definitions, items: itemRows, total: 42, values })
+    const event = createTestEvent(db.dbHttp)
+
+    getValidatedQueryMock.mockResolvedValue(createQuery({ limit: 10, page: 2 }))
+
+    const result = await listItemsHandler(event)
+
+    expect(result).toStrictEqual({
+      items: [{
+        id,
+        name: 'PocketRocket Deluxe',
+        brand: { name: 'MSR', slug: 'msr' },
+        category: { name: 'Stoves', slug: 'stoves' },
+
+        properties: [
+          { dataType: 'number', name: 'Weight', slug: 'weight', unit: 'g', value: 83 },
+          { dataType: 'boolean', name: 'Piezo', slug: 'piezo', unit: null, value: true },
+          { dataType: 'enum', name: 'Fuel', slug: 'fuel', unit: null, value: null }
+        ]
+      }, {
+        id: secondId,
+        name: 'Solo Pot',
+        brand: { name: 'Solo', slug: 'solo' },
+        category: { name: 'Cookware', slug: 'cookware' },
+
+        properties: [
+          { dataType: 'number', name: 'Volume', slug: 'volume', unit: 'ml', value: null }
+        ]
+      }],
+      limit: 10,
+      page: 2,
+      total: 42
+    })
+    expect(db.itemsLimitMock).toHaveBeenCalledWith(10)
+    expect(db.itemsOffsetMock).toHaveBeenCalledWith(10)
+    expect(db.definitionsOrderByMock).toHaveBeenCalledTimes(1)
+    const [definitionOrderFragments] = db.definitionsOrderByMock.mock.calls
+
+    expect(definitionOrderFragments?.map((fragment) => compactSql(fragment))).toStrictEqual([
+      '"category_properties"."categoryId" asc',
+      '"category_properties"."displayOrder" asc',
+      '"category_properties"."id" asc'
+    ])
+    expect(db.selectMock).toHaveBeenCalledTimes(4)
+    expect(db.countWhereMock.mock.calls[0]?.[0]).toBe(db.itemsWhereMock.mock.calls[0]?.[0])
+  })
+
+  it('should compile grouped search, brand, enum, numeric, and boolean predicates', async () => {
+    const db = createListDb({ categoryMetadata: createCategoryMetadata() })
+    const query = createQuery({
+      booleanFilter: [{ propertySlug: 'piezo', value: true }],
+      brandSlug: ['msr', 'therm-a-rest'],
+      categorySlug: 'stoves',
+      enumFilter: [
+        { optionSlug: 'canister', propertySlug: 'fuel' },
+        { optionSlug: 'alcohol', propertySlug: 'fuel' }
+      ],
+      numberFilter: [{ max: 100, min: 80, propertySlug: 'weight' }],
+      search: String.raw`Neo\%_`
+    })
+
+    const event = createTestEvent(db.dbHttp)
+
+    getValidatedQueryMock.mockResolvedValue(query)
+
+    await listItemsHandler(event)
+
+    const where = db.itemsWhereMock.mock.calls[0]?.[0]
+    const compiled = compileSql(where)
+    const statement = compiled.sql.replaceAll(/\s+/gu, ' ')
+    const escapedSearch = String.raw`%Neo\\\%\_%`
+
+    expect(compiled.params).toStrictEqual(expect.arrayContaining([
+      'approved',
+      'stoves',
+      'msr',
+      'therm-a-rest',
+      escapedSearch,
+      10,
+      '80',
+      '100',
+      11,
+      'canister',
+      'alcohol',
+      12,
+      true
+    ]))
+    expect(compiled.params.filter((parameter) => parameter === escapedSearch)).toHaveLength(3)
+    expect(statement.match(/exists \(/gu)).toHaveLength(3)
+    expect(statement).toContain('"valueNumber" >=')
+    expect(statement).toContain('"valueNumber" <=')
+    expect(statement).toMatch(/\("filter_values"\."valueText" = \$\d+\) or \("filter_values"\."valueText" = \$\d+\)/u)
+    expect(statement).toMatch(/\("brands"\."slug" = \$\d+\) or \("brands"\."slug" = \$\d+\)/u)
+    expect(statement).toContain('"equipment_items"."name" ilike')
+    expect(statement).toContain('"brands"."name" ilike')
+    expect(statement).toContain('"equipment_categories"."name" ilike')
+    expect(statement).toMatch(
+      /^\(\("equipment_items"\."status" = \$\d+\) and \("equipment_categories"\."slug" = \$\d+\) and /u
+    )
+    expect(statement).toMatch(
+      /"brands"\."slug" = \$\d+\)\)\) and \(\(\("equipment_items"\."name" ilike/u
+    )
+    expect(statement.match(/\)+ and \(exists \(/gu)).toHaveLength(3)
+  })
+
+  it.each(['asc', 'desc'] as const)(
+    'should left join numeric %s sorting with nulls last and stable tie-breakers',
+    async (direction) => {
+      const db = createListDb({ categoryMetadata: createCategoryMetadata() })
+      const query = createQuery({
+        categorySlug: 'stoves',
+        direction,
+        sort: 'property:weight'
+      })
+      const event = createTestEvent(db.dbHttp)
+
+      getValidatedQueryMock.mockResolvedValue(query)
+
+      await listItemsHandler(event)
+
+      const joinCondition = db.itemsLeftJoinMock.mock.calls[0]?.[1]
+      const [orderFragments] = db.itemsOrderByMock.mock.calls
+
+      expect(db.itemsLeftJoinMock).toHaveBeenCalledTimes(1)
+      expect(compileSql(joinCondition).params).toContain(10)
+      expect(orderFragments?.map((fragment) => compactSql(fragment))).toStrictEqual([
+        `"property_sort_values"."valueNumber" ${direction} nulls last`,
+        '"equipment_items"."name" asc',
+        '"equipment_items"."id" asc'
+      ])
+    }
+  )
+
+  it.each([
+    ['name', 'desc', ['"equipment_items"."name" desc', '"equipment_items"."id" asc']],
+    ['brand', 'desc', ['"brands"."name" desc', '"equipment_items"."name" asc', '"equipment_items"."id" asc']]
+  ] as const)('should stabilize %s sorting', async (sort, direction, expectedOrder) => {
+    const db = createListDb()
+    const event = createTestEvent(db.dbHttp)
+
+    getValidatedQueryMock.mockResolvedValue(createQuery({ direction, sort }))
+
+    await listItemsHandler(event)
+
+    const [orderFragments] = db.itemsOrderByMock.mock.calls
+
+    expect(orderFragments?.map((fragment) => compactSql(fragment))).toStrictEqual(expectedOrder)
+  })
+
+  it.each([
+    ['unknown category', undefined, createQuery({ categorySlug: 'unknown', numberFilter: [{ min: 1, max: null, propertySlug: 'weight' }] })],
+    ['wrong data type', createCategoryMetadata(), createQuery({ categorySlug: 'stoves', numberFilter: [{ min: 1, max: null, propertySlug: 'fuel' }] })],
+    ['unknown property', createCategoryMetadata(), createQuery({ categorySlug: 'stoves', numberFilter: [{ min: 1, max: null, propertySlug: 'capacity' }] })],
+    ['unknown enum option', createCategoryMetadata(), createQuery({ categorySlug: 'stoves', enumFilter: [{ optionSlug: 'gasoline', propertySlug: 'fuel' }] })],
+    ['non-numeric property sort', createCategoryMetadata(), createQuery({ categorySlug: 'stoves', sort: 'property:fuel' })]
+  ])('should reject %s metadata', async (_name, categoryMetadata, query) => {
+    const db = createListDb({ categoryMetadata })
+    const event = createTestEvent(db.dbHttp)
+
+    getValidatedQueryMock.mockResolvedValue(query)
+
+    await expect(listItemsHandler(event)).rejects.toMatchObject({
+      statusCode: 400
+    })
+  })
+
+  it('should keep unknown brand and category slugs as zero-match SQL filters', async () => {
+    const db = createListDb()
+    const query = createQuery({ brandSlug: ['unknown-brand'], categorySlug: 'unknown-category' })
+    const event = createTestEvent(db.dbHttp)
+
+    getValidatedQueryMock.mockResolvedValue(query)
+
+    await listItemsHandler(event)
+
+    const compiled = compileSql(db.itemsWhereMock.mock.calls[0]?.[0])
+
+    expect(compiled.params).toStrictEqual(expect.arrayContaining(['unknown-brand', 'unknown-category']))
+    expect(db.findFirstMock).not.toHaveBeenCalled()
+  })
+
+  it('should stop before database queries when query validation fails', async () => {
+    const db = createListDb()
+    const event = createTestEvent(db.dbHttp)
+
+    getValidatedQueryMock.mockRejectedValue(h3.createError({ status: 400 }))
+
+    await expect(listItemsHandler(event)).rejects.toMatchObject({ statusCode: 400 })
+    expect(db.selectMock).not.toHaveBeenCalled()
+  })
+})

--- a/server/api/equipment/items/__tests__/reads.test.ts
+++ b/server/api/equipment/items/__tests__/reads.test.ts
@@ -1,15 +1,10 @@
 import * as h3 from 'h3'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import itemDetailHandler from '#server/api/equipment/items/[id].get'
-import listItemsHandler from '#server/api/equipment/items/index.get'
 import { createTestEvent } from '~~/test-utils/create-test-event'
 
-const {
-  getValidatedQueryMock,
-  getValidatedRouterParamsMock
-} = vi.hoisted(() => {
+const { getValidatedRouterParamsMock } = vi.hoisted(() => {
   return {
-    getValidatedQueryMock: vi.fn<typeof h3.getValidatedQuery>(),
     getValidatedRouterParamsMock: vi.fn<typeof h3.getValidatedRouterParams>()
   }
 })
@@ -21,105 +16,45 @@ vi.mock(import('h3'), async () => {
   return {
     ...actual,
 
-    async getValidatedQuery(...args: Parameters<typeof h3.getValidatedQuery>) {
-      return getValidatedQueryMock(...args)
-    },
-
     async getValidatedRouterParams(...args: Parameters<typeof h3.getValidatedRouterParams>) {
       return getValidatedRouterParamsMock(...args)
     }
   }
 })
 
-function createListDb({
-  items = [],
-  total = 0
-}: {
-  items?: unknown[];
-  total?: number;
-} = {}) {
-  const itemsOffsetMock = vi.fn(() => items)
-  const itemsLimitMock = vi.fn(() => {
-    return {
-      offset: itemsOffsetMock
-    }
-  })
+interface DetailPropertyColumns {
+  displayOrder: boolean;
+  id: boolean;
+}
 
-  const itemsOrderByMock = vi.fn(() => {
-    return {
-      limit: itemsLimitMock
-    }
-  })
+interface DetailPropertyConfig {
+  columns: DetailPropertyColumns;
+}
 
-  const itemsWhereMock = vi.fn(() => {
-    return {
-      orderBy: itemsOrderByMock
-    }
-  })
+interface DetailPropertyRelationConfig {
+  property: DetailPropertyConfig;
+}
 
-  const itemsCategoryJoinMock = vi.fn(() => {
-    return {
-      where: itemsWhereMock
-    }
-  })
+interface DetailPropertyValuesConfig {
+  with: DetailPropertyRelationConfig;
+}
 
-  const itemsBrandJoinMock = vi.fn(() => {
-    return {
-      innerJoin: itemsCategoryJoinMock
-    }
-  })
+interface DetailRelationsConfig {
+  propertyValues: DetailPropertyValuesConfig;
+}
 
-  const itemsFromMock = vi.fn(() => {
-    return {
-      innerJoin: itemsBrandJoinMock
-    }
-  })
+interface DetailWhereConfig {
+  id: string;
+  status: string;
+}
 
-  const countWhereMock = vi.fn(() => [{
-    total
-  }])
-
-  const countCategoryJoinMock = vi.fn(() => {
-    return {
-      where: countWhereMock
-    }
-  })
-
-  const countBrandJoinMock = vi.fn(() => {
-    return {
-      innerJoin: countCategoryJoinMock
-    }
-  })
-
-  const countFromMock = vi.fn(() => {
-    return {
-      innerJoin: countBrandJoinMock
-    }
-  })
-
-  const selectMock = vi.fn()
-
-  selectMock
-    .mockReturnValueOnce({
-      from: itemsFromMock
-    })
-    .mockReturnValueOnce({
-      from: countFromMock
-    })
-
-  return {
-    dbHttp: {
-      select: selectMock
-    },
-    itemsLimitMock,
-    itemsOffsetMock,
-    itemsOrderByMock,
-    itemsWhereMock
-  }
+interface DetailQueryConfig {
+  where: DetailWhereConfig;
+  with: DetailRelationsConfig;
 }
 
 function createDetailDb(item?: unknown) {
-  const findFirstMock = vi.fn(() => item)
+  const findFirstMock = vi.fn((_config: DetailQueryConfig) => item)
 
   return {
     dbHttp: {
@@ -133,17 +68,9 @@ function createDetailDb(item?: unknown) {
   }
 }
 
-describe('item read handlers', () => {
+describe('get /api/equipment/items/[id]', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-
-    getValidatedQueryMock.mockResolvedValue({
-      brandSlug: undefined,
-      categorySlug: undefined,
-      limit: 20,
-      page: 1,
-      search: ''
-    })
 
     getValidatedRouterParamsMock.mockResolvedValue({
       id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
@@ -154,237 +81,164 @@ describe('item read handlers', () => {
     vi.restoreAllMocks()
   })
 
-  describe('get /api/equipment/items', () => {
-    it('should return paginated items list', async () => {
-      const items = [{
-        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
-        name: 'NeoAir XLite NXT Regular',
+  it('should return approved item detail with ordered normalized property values', async () => {
+    const item = {
+      createdAt: '2026-04-01T00:00:00Z',
+      id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+      name: 'PocketRocket Deluxe',
 
-        brand: {
-          name: 'Therm-a-Rest',
-          slug: 'therm-a-rest'
-        },
+      brand: {
+        id: 1,
+        name: 'MSR',
+        slug: 'msr'
+      },
 
-        category: {
-          name: 'Sleeping Pads',
-          slug: 'sleeping-pads'
+      category: {
+        id: 2,
+        name: 'Stoves',
+        slug: 'stoves'
+      },
+
+      propertyValues: [{
+        valueBoolean: null,
+        valueNumber: '83',
+        valueText: null,
+
+        property: {
+          dataType: 'number',
+          displayOrder: 2,
+          id: 3,
+          name: 'Weight',
+          slug: 'weight',
+          unit: 'g'
         }
-      }]
+      }, {
+        valueBoolean: true,
+        valueNumber: null,
+        valueText: null,
 
-      const { dbHttp, itemsLimitMock, itemsOffsetMock, itemsOrderByMock, itemsWhereMock } = createListDb({
-        items,
-        total: 42
-      })
-
-      const event = createTestEvent(dbHttp)
-
-      getValidatedQueryMock.mockResolvedValue({
-        brandSlug: 'therm-a-rest',
-        categorySlug: 'sleeping-pads',
-        limit: 10,
-        page: 2,
-        search: 'neoair'
-      })
-
-      const result = await listItemsHandler(event)
-
-      expect(result).toStrictEqual({
-        items,
-        limit: 10,
-        page: 2,
-        total: 42
-      })
-
-      expect(itemsWhereMock).toHaveBeenCalledTimes(1)
-      expect(itemsOrderByMock).toHaveBeenCalledTimes(1)
-      expect(itemsLimitMock).toHaveBeenCalledWith(10)
-      expect(itemsOffsetMock).toHaveBeenCalledWith(10)
-    })
-
-    it('should use the clamped list limit returned by query validation', async () => {
-      const items = [{
-        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
-        name: 'PocketRocket Deluxe',
-
-        brand: {
-          name: 'MSR',
-          slug: 'msr'
-        },
-
-        category: {
-          name: 'Stoves',
-          slug: 'stoves'
+        property: {
+          dataType: 'boolean',
+          displayOrder: 0,
+          id: 1,
+          name: 'Piezo',
+          slug: 'piezo',
+          unit: null
         }
+      }, {
+        valueBoolean: null,
+        valueNumber: null,
+        valueText: null,
+
+        property: {
+          dataType: 'text',
+          displayOrder: 3,
+          id: 4,
+          name: 'Notes',
+          slug: 'notes',
+          unit: null
+        }
+      }, {
+        valueBoolean: null,
+        valueNumber: null,
+        valueText: 'canister',
+
+        property: {
+          dataType: 'enum',
+          displayOrder: 1,
+          id: 2,
+          name: 'Fuel',
+          slug: 'fuel',
+          unit: null
+        }
+      }, {
+        valueBoolean: null,
+        valueNumber: null,
+        valueText: 'ignore-me',
+        property: null
       }]
+    }
+    const { dbHttp, findFirstMock } = createDetailDb(item)
+    const event = createTestEvent(dbHttp)
+    const result = await itemDetailHandler(event)
 
-      const { dbHttp, itemsLimitMock, itemsOffsetMock } = createListDb({
-        items,
-        total: 250
-      })
+    expect(result).toStrictEqual({
+      createdAt: '2026-04-01T00:00:00Z',
+      id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+      name: 'PocketRocket Deluxe',
 
-      const event = createTestEvent(dbHttp)
+      brand: {
+        id: 1,
+        name: 'MSR',
+        slug: 'msr'
+      },
 
-      getValidatedQueryMock.mockResolvedValue({
-        brandSlug: undefined,
-        categorySlug: undefined,
-        limit: 100,
-        page: 3,
-        search: ''
-      })
+      category: {
+        id: 2,
+        name: 'Stoves',
+        slug: 'stoves'
+      },
 
-      const result = await listItemsHandler(event)
-
-      expect(result).toStrictEqual({
-        items,
-        limit: 100,
-        page: 3,
-        total: 250
-      })
-
-      expect(itemsLimitMock).toHaveBeenCalledWith(100)
-      expect(itemsOffsetMock).toHaveBeenCalledWith(200)
+      properties: [{
+        dataType: 'boolean',
+        name: 'Piezo',
+        slug: 'piezo',
+        unit: null,
+        value: true
+      }, {
+        dataType: 'enum',
+        name: 'Fuel',
+        slug: 'fuel',
+        unit: null,
+        value: 'canister'
+      }, {
+        dataType: 'number',
+        name: 'Weight',
+        slug: 'weight',
+        unit: 'g',
+        value: 83
+      }, {
+        dataType: 'text',
+        name: 'Notes',
+        slug: 'notes',
+        unit: null,
+        value: null
+      }]
     })
+    const [findFirstCall] = findFirstMock.mock.calls
+    const queryConfig = findFirstCall?.[0]
 
-    it('should return 400 when query validation fails', async () => {
-      const queryError = h3.createError({ status: 400 })
-      const { dbHttp } = createListDb()
-      const event = createTestEvent(dbHttp)
+    expect(queryConfig?.where).toStrictEqual({
+      id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+      status: 'approved'
+    })
+    expect(queryConfig?.with.propertyValues.with.property.columns).toStrictEqual(expect.objectContaining({
+      displayOrder: true,
+      id: true
+    }))
+  })
 
-      getValidatedQueryMock.mockRejectedValue(queryError)
+  it('should return 400 when route params validation fails', async () => {
+    const routeError = h3.createError({ status: 400 })
+    const { dbHttp } = createDetailDb()
+    const event = createTestEvent(dbHttp)
 
-      await expect(listItemsHandler(event)).rejects.toMatchObject({
-        statusCode: 400
-      })
+    getValidatedRouterParamsMock.mockRejectedValue(routeError)
+
+    await expect(itemDetailHandler(event)).rejects.toMatchObject({
+      statusCode: 400
     })
   })
 
-  describe('get /api/equipment/items/[id]', () => {
-    it('should return item detail with normalized property values', async () => {
-      const item = {
-        createdAt: '2026-04-01T00:00:00Z',
-        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
-        name: 'PocketRocket Deluxe',
-        status: 'approved',
-
-        brand: {
-          id: 1,
-          name: 'MSR',
-          slug: 'msr'
-        },
-
-        category: {
-          id: 2,
-          name: 'Stoves',
-          slug: 'stoves'
-        },
-
-        propertyValues: [{
-          valueBoolean: null,
-          valueNumber: '83',
-          valueText: null,
-
-          property: {
-            dataType: 'number',
-            name: 'Weight',
-            slug: 'weight',
-            unit: 'g'
-          }
-        }, {
-          valueBoolean: true,
-          valueNumber: null,
-          valueText: null,
-
-          property: {
-            dataType: 'boolean',
-            name: 'Piezo',
-            slug: 'piezo',
-            unit: null
-          }
-        }, {
-          valueBoolean: null,
-          valueNumber: null,
-          valueText: 'canister',
-
-          property: {
-            dataType: 'enum',
-            name: 'Fuel',
-            slug: 'fuel',
-            unit: null
-          }
-        }, {
-          valueBoolean: null,
-          valueNumber: null,
-          valueText: 'ignore-me',
-
-          property: null
-        }]
-      }
-
-      const { dbHttp, findFirstMock } = createDetailDb(item)
-      const event = createTestEvent(dbHttp)
-      const result = await itemDetailHandler(event)
-
-      expect(result).toStrictEqual({
-        createdAt: '2026-04-01T00:00:00Z',
-        id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
-        name: 'PocketRocket Deluxe',
-        status: 'approved',
-
-        brand: {
-          id: 1,
-          name: 'MSR',
-          slug: 'msr'
-        },
-
-        category: {
-          id: 2,
-          name: 'Stoves',
-          slug: 'stoves'
-        },
-
-        properties: [{
-          dataType: 'number',
-          name: 'Weight',
-          slug: 'weight',
-          unit: 'g',
-          value: '83'
-        }, {
-          dataType: 'boolean',
-          name: 'Piezo',
-          slug: 'piezo',
-          unit: null,
-          value: 'true'
-        }, {
-          dataType: 'enum',
-          name: 'Fuel',
-          slug: 'fuel',
-          unit: null,
-          value: 'canister'
-        }]
-      })
-
-      expect(findFirstMock).toHaveBeenCalledTimes(1)
-    })
-
-    it('should return 400 when route params validation fails', async () => {
-      const routeError = h3.createError({ status: 400 })
-      const { dbHttp } = createDetailDb()
-      const event = createTestEvent(dbHttp)
-
-      getValidatedRouterParamsMock.mockRejectedValue(routeError)
-
-      await expect(itemDetailHandler(event)).rejects.toMatchObject({
-        statusCode: 400
-      })
-    })
-
-    it('should return 404 when item id does not exist', async () => {
+  it.each(['missing', 'pending', 'rejected'])(
+    'should return 404 when the item is %s',
+    async () => {
       const { dbHttp } = createDetailDb()
       const event = createTestEvent(dbHttp)
 
       await expect(itemDetailHandler(event)).rejects.toMatchObject({
         statusCode: 404
       })
-    })
-  })
+    }
+  )
 })

--- a/server/api/equipment/items/index.get.ts
+++ b/server/api/equipment/items/index.get.ts
@@ -1,27 +1,19 @@
-import { and, asc, count, eq, ilike, type SQL } from 'drizzle-orm'
+import { and, count, eq } from 'drizzle-orm'
 import { defineEventHandler, getValidatedQuery } from 'h3'
 import { brands, equipmentCategories, equipmentItems } from '#server/database/schema'
+import {
+  buildCatalogListSql,
+  catalogPropertySortValues,
+  type CatalogListItemRow
+} from '#server/utils/equipment/catalog-list'
+import {
+  enrichCatalogItemRows,
+  type CatalogListItem
+} from '#server/utils/equipment/catalog-list-enrichment'
 import { validateItemsListQuery } from '#server/utils/validation/schemas'
 
-interface Brand {
-  name: string;
-  slug: string;
-}
-
-interface Category {
-  name: string;
-  slug: string;
-}
-
-interface EquipmentItem {
-  id: string;
-  name: string;
-  brand: Brand;
-  category: Category;
-}
-
 interface ReturnData {
-  items: EquipmentItem[];
+  items: CatalogListItem[];
   limit: number;
   page: number;
   total: number;
@@ -30,84 +22,56 @@ interface ReturnData {
 export default defineEventHandler(async (event) : Promise<ReturnData> => {
   const { dbHttp } = event.context
   const validatedQuery = await getValidatedQuery(event, validateItemsListQuery)
+  const { limit, page } = validatedQuery
+  const { orderBy, sortPropertyId, where } = await buildCatalogListSql(dbHttp, validatedQuery)
+  const selection = {
+    categoryId: equipmentItems.categoryId,
+    id: equipmentItems.id,
+    name: equipmentItems.name,
 
-  const {
-    brandSlug,
-    categorySlug,
-    limit,
-    page,
-    search
-  } = validatedQuery
+    brand: {
+      name: brands.name,
+      slug: brands.slug
+    },
 
-  const conditions: SQL[] = [
-    eq(equipmentItems.status, 'approved')
-  ]
-
-  if (categorySlug !== undefined && categorySlug !== '') {
-    conditions.push(
-      eq(equipmentCategories.slug, categorySlug)
-    )
+    category: {
+      name: equipmentCategories.name,
+      slug: equipmentCategories.slug
+    }
   }
-
-  if (brandSlug !== undefined && brandSlug !== '') {
-    conditions.push(
-      eq(brands.slug, brandSlug)
-    )
-  }
-
-  if (search !== '') {
-    const escapedSearch = search
-      .replaceAll('%', String.raw`\%`)
-      .replaceAll('_', String.raw`\_`)
-
-    conditions.push(
-      ilike(equipmentItems.name, `%${escapedSearch}%`)
-    )
-  }
-
-  const where = and(...conditions)
-
-  const [items, countRows] = await Promise.all([
-    dbHttp
-      .select({
-        id: equipmentItems.id,
-        name: equipmentItems.name,
-
-        brand: {
-          name: brands.name,
-          slug: brands.slug
-        },
-
-        category: {
-          name: equipmentCategories.name,
-          slug: equipmentCategories.slug
-        }
-      })
-      .from(equipmentItems)
-      .innerJoin(brands, eq(equipmentItems.brandId, brands.id))
-      .innerJoin(equipmentCategories, eq(equipmentItems.categoryId, equipmentCategories.id))
-      .where(where)
-      .orderBy(
-        asc(equipmentItems.name),
-        asc(equipmentItems.id)
-      )
-      .limit(limit)
-      .offset((page - 1) * limit),
-
-    dbHttp
-      .select({ total: count() })
-      .from(equipmentItems)
-      .innerJoin(brands, eq(equipmentItems.brandId, brands.id))
-      .innerJoin(equipmentCategories, eq(equipmentItems.categoryId, equipmentCategories.id))
-      .where(where)
-  ])
-
+  const baseItemsQuery = dbHttp
+    .select(selection)
+    .from(equipmentItems)
+    .innerJoin(brands, eq(equipmentItems.brandId, brands.id))
+    .innerJoin(equipmentCategories, eq(equipmentItems.categoryId, equipmentCategories.id))
+  const itemsPromise = sortPropertyId === undefined
+    ? baseItemsQuery
+        .where(where)
+        .orderBy(...orderBy)
+        .limit(limit)
+        .offset((page - 1) * limit)
+    : baseItemsQuery
+        .leftJoin(
+          catalogPropertySortValues,
+          and(
+            eq(catalogPropertySortValues.itemId, equipmentItems.id),
+            eq(catalogPropertySortValues.propertyId, sortPropertyId)
+          )
+        )
+        .where(where)
+        .orderBy(...orderBy)
+        .limit(limit)
+        .offset((page - 1) * limit)
+  const countPromise = dbHttp
+    .select({ total: count() })
+    .from(equipmentItems)
+    .innerJoin(brands, eq(equipmentItems.brandId, brands.id))
+    .innerJoin(equipmentCategories, eq(equipmentItems.categoryId, equipmentCategories.id))
+    .where(where)
+  const [itemResults, countRows] = await Promise.all([itemsPromise, countPromise])
+  const itemRows = itemResults as CatalogListItemRow[]
+  const items = await enrichCatalogItemRows(dbHttp, itemRows)
   const total = countRows[0]?.total ?? 0
 
-  return {
-    items,
-    limit,
-    page,
-    total
-  }
+  return { items, limit, page, total }
 })

--- a/server/utils/equipment/__tests__/property-values.test.ts
+++ b/server/utils/equipment/__tests__/property-values.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getEquipmentPropertyDataType,
+  normalizeEquipmentPropertyValue,
+  type EquipmentPropertyDataType
+} from '../property-values'
+
+describe('equipment property values', () => {
+  it.each([
+    {
+      expectedValue: true,
+      input: { dataType: 'boolean', valueBoolean: true, valueNumber: null, valueText: null }
+    },
+    {
+      expectedValue: null,
+      input: { dataType: 'boolean', valueBoolean: null, valueNumber: null, valueText: null }
+    },
+    {
+      expectedValue: 'canister',
+      input: { dataType: 'enum', valueBoolean: null, valueNumber: null, valueText: 'canister' }
+    },
+    {
+      expectedValue: 83.5,
+      input: { dataType: 'number', valueBoolean: null, valueNumber: '83.5', valueText: null }
+    },
+    {
+      expectedValue: null,
+      input: { dataType: 'number', valueBoolean: null, valueNumber: null, valueText: null }
+    },
+    {
+      expectedValue: 'three-season',
+      input: { dataType: 'text', valueBoolean: null, valueNumber: null, valueText: 'three-season' }
+    }
+  ] as const)('should normalize a $input.dataType property value', ({ expectedValue, input }) => {
+    const value = normalizeEquipmentPropertyValue(input)
+
+    expect(value).toBe(expectedValue)
+  })
+
+  it.each<EquipmentPropertyDataType>([
+    'boolean',
+    'enum',
+    'number',
+    'text'
+  ])('should accept the supported %s data type', (dataType) => {
+    expect(getEquipmentPropertyDataType(dataType)).toBe(dataType)
+  })
+
+  it('should reject an unsupported database data type', () => {
+    expect(() => getEquipmentPropertyDataType('decimal')).toThrow(expect.objectContaining({
+      statusCode: 500
+    }))
+  })
+})

--- a/server/utils/equipment/catalog-list-enrichment.ts
+++ b/server/utils/equipment/catalog-list-enrichment.ts
@@ -1,0 +1,170 @@
+import { asc, inArray } from 'drizzle-orm'
+import { categoryProperties, itemPropertyValues } from '#server/database/schema'
+import type { createHttpClient } from '#server/utils/database'
+import type {
+  CatalogListBrand,
+  CatalogListCategory,
+  CatalogListItemRow
+} from '#server/utils/equipment/catalog-list'
+import {
+  getEquipmentPropertyDataType,
+  normalizeEquipmentPropertyValue,
+  type EquipmentPropertyDataType,
+  type EquipmentPropertyValue
+} from '#server/utils/equipment/property-values'
+
+type DbHttp = ReturnType<typeof createHttpClient>
+
+interface CatalogListProperty {
+  dataType: EquipmentPropertyDataType;
+  name: string;
+  slug: string;
+  unit: string | null;
+  value: EquipmentPropertyValue;
+}
+
+interface CatalogListItem {
+  brand: CatalogListBrand;
+  category: CatalogListCategory;
+  id: string;
+  name: string;
+  properties: CatalogListProperty[];
+}
+
+interface PropertyDefinitionRow {
+  categoryId: number;
+  dataType: string;
+  displayOrder: number;
+  id: number;
+  name: string;
+  slug: string;
+  unit: string | null;
+}
+
+interface PropertyValueRow {
+  itemId: string;
+  propertyId: number;
+  valueBoolean: boolean | null;
+  valueNumber: string | null;
+  valueText: string | null;
+}
+
+function groupDefinitions(rows: PropertyDefinitionRow[]) {
+  const definitionsByCategoryId = new Map<number, PropertyDefinitionRow[]>()
+
+  for (const row of rows) {
+    const definitions = definitionsByCategoryId.get(row.categoryId)
+
+    if (definitions === undefined) {
+      definitionsByCategoryId.set(row.categoryId, [row])
+    } else if (definitions.length < 3) {
+      definitions.push(row)
+    }
+  }
+
+  return definitionsByCategoryId
+}
+
+function groupValues(rows: PropertyValueRow[]) {
+  const valuesByItemId = new Map<string, Map<number, PropertyValueRow>>()
+
+  for (const row of rows) {
+    const itemValues = valuesByItemId.get(row.itemId)
+
+    if (itemValues === undefined) {
+      valuesByItemId.set(row.itemId, new Map([[row.propertyId, row]]))
+    } else {
+      itemValues.set(row.propertyId, row)
+    }
+  }
+
+  return valuesByItemId
+}
+
+/** Loads ordered key-property definitions and shapes catalog rows without per-item queries. */
+async function enrichCatalogItemRows(dbHttp: DbHttp, itemRows: CatalogListItemRow[]) : Promise<CatalogListItem[]> {
+  if (itemRows.length === 0) {
+    return []
+  }
+
+  const categoryIdValues = itemRows.map((item) => item.categoryId)
+  const uniqueCategoryIds = new Set(categoryIdValues)
+  const categoryIds = [...uniqueCategoryIds]
+  const itemIds = itemRows.map((item) => item.id)
+  const definitionsPromise = dbHttp
+    .select({
+      categoryId: categoryProperties.categoryId,
+      dataType: categoryProperties.dataType,
+      displayOrder: categoryProperties.displayOrder,
+      id: categoryProperties.id,
+      name: categoryProperties.name,
+      slug: categoryProperties.slug,
+      unit: categoryProperties.unit
+    })
+    .from(categoryProperties)
+    .where(
+      inArray(categoryProperties.categoryId, categoryIds)
+    )
+    .orderBy(
+      asc(categoryProperties.categoryId),
+      asc(categoryProperties.displayOrder),
+      asc(categoryProperties.id)
+    )
+  const valuesPromise = dbHttp
+    .select({
+      itemId: itemPropertyValues.itemId,
+      propertyId: itemPropertyValues.propertyId,
+      valueBoolean: itemPropertyValues.valueBoolean,
+      valueNumber: itemPropertyValues.valueNumber,
+      valueText: itemPropertyValues.valueText
+    })
+    .from(itemPropertyValues)
+    .where(
+      inArray(itemPropertyValues.itemId, itemIds)
+    )
+  const [definitionRows, valueRows] = await Promise.all([definitionsPromise, valuesPromise])
+  const definitionsByCategoryId = groupDefinitions(definitionRows)
+  const valuesByItemId = groupValues(valueRows)
+
+  return itemRows.map((item) => {
+    const definitions = definitionsByCategoryId.get(item.categoryId) ?? []
+    const itemValues = valuesByItemId.get(item.id)
+    const properties = definitions.map((definition): CatalogListProperty => {
+      const dataType = getEquipmentPropertyDataType(definition.dataType)
+      const storedValue = itemValues?.get(definition.id)
+      const value = storedValue === undefined
+        ? null
+        : normalizeEquipmentPropertyValue({
+            dataType,
+            valueBoolean: storedValue.valueBoolean,
+            valueNumber: storedValue.valueNumber,
+            valueText: storedValue.valueText
+          })
+
+      return {
+        dataType,
+        name: definition.name,
+        slug: definition.slug,
+        unit: definition.unit,
+        value
+      }
+    })
+
+    return {
+      brand: item.brand,
+      category: item.category,
+      id: item.id,
+      name: item.name,
+      properties
+    }
+  })
+}
+
+export {
+  enrichCatalogItemRows
+}
+
+export type {
+  CatalogListItem,
+  CatalogListProperty
+}

--- a/server/utils/equipment/catalog-list.ts
+++ b/server/utils/equipment/catalog-list.ts
@@ -1,0 +1,338 @@
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gte,
+  ilike,
+  lte,
+  or,
+  sql,
+  type SQL
+} from 'drizzle-orm'
+import { alias } from 'drizzle-orm/pg-core'
+import { createError } from 'h3'
+import {
+  brands,
+  equipmentCategories,
+  equipmentItems,
+  itemPropertyValues
+} from '#server/database/schema'
+import type { createHttpClient } from '#server/utils/database'
+import type {
+  ItemsListBooleanFilter,
+  ItemsListEnumFilter,
+  ItemsListNumberFilter,
+  ItemsListSort,
+  validateItemsListQuery
+} from '#server/utils/validation/schemas'
+
+type DbHttp = ReturnType<typeof createHttpClient>
+type ItemsListQuery = ReturnType<typeof validateItemsListQuery>
+
+interface CatalogListBrand {
+  name: string;
+  slug: string;
+}
+
+interface CatalogListCategory {
+  name: string;
+  slug: string;
+}
+
+interface CatalogListItemRow {
+  brand: CatalogListBrand;
+  category: CatalogListCategory;
+  categoryId: number;
+  id: string;
+  name: string;
+}
+
+interface CatalogListSql {
+  orderBy: SQL[];
+  sortPropertyId: number | undefined;
+  where: SQL | undefined;
+}
+
+interface CategoryMetadataEnumOption {
+  slug: string;
+}
+
+interface CategoryMetadataProperty {
+  dataType: string;
+  enumOptions: CategoryMetadataEnumOption[];
+  id: number;
+  slug: string;
+}
+
+interface CategoryMetadata {
+  properties: CategoryMetadataProperty[];
+}
+
+interface EnumFilterGroup {
+  optionSlugs: string[];
+  propertyId: number;
+}
+
+const filterValues = alias(itemPropertyValues, 'filter_values')
+const catalogPropertySortValues = alias(itemPropertyValues, 'property_sort_values')
+
+function escapeLikePattern(value: string) {
+  return value
+    .replaceAll('\\', String.raw`\\`)
+    .replaceAll('%', String.raw`\%`)
+    .replaceAll('_', String.raw`\_`)
+}
+
+function createPropertyExistsCondition(propertyId: number, valueConditions: SQL[]) : SQL {
+  const filterCondition = and(
+    eq(filterValues.itemId, equipmentItems.id),
+    eq(filterValues.propertyId, propertyId),
+    ...valueConditions
+  )
+
+  return sql`exists (
+    select 1
+    from ${itemPropertyValues} as ${sql.identifier('filter_values')}
+    where ${filterCondition}
+  )`
+}
+
+function createBaseConditions(query: ItemsListQuery) : SQL[] {
+  const conditions: SQL[] = [eq(equipmentItems.status, 'approved')]
+
+  if (query.categorySlug !== undefined) {
+    conditions.push(eq(equipmentCategories.slug, query.categorySlug))
+  }
+
+  if (query.brandSlug.length > 0) {
+    const brandCondition = or(...query.brandSlug.map((slug) => eq(brands.slug, slug)))
+
+    if (brandCondition !== undefined) {
+      conditions.push(brandCondition)
+    }
+  }
+
+  if (query.search !== '') {
+    const escapedSearch = escapeLikePattern(query.search)
+    const containsPattern = `%${escapedSearch}%`
+    const searchCondition = or(
+      ilike(equipmentItems.name, containsPattern),
+      ilike(brands.name, containsPattern),
+      ilike(equipmentCategories.name, containsPattern)
+    )
+
+    if (searchCondition !== undefined) {
+      conditions.push(searchCondition)
+    }
+  }
+
+  return conditions
+}
+
+async function loadCategoryMetadata(dbHttp: DbHttp, query: ItemsListQuery) : Promise<CategoryMetadata | undefined> {
+  const hasPropertyFilters = query.numberFilter.length > 0
+    || query.enumFilter.length > 0
+    || query.booleanFilter.length > 0
+  const requiresMetadata = hasPropertyFilters || query.sort.startsWith('property:')
+
+  if (!requiresMetadata) {
+    return undefined
+  }
+
+  if (query.categorySlug === undefined) {
+    throw createError({ status: 400, message: 'categorySlug is required for property filters and sorting' })
+  }
+
+  const metadata = await dbHttp.query.equipmentCategories.findFirst({
+    columns: {
+      id: true
+    },
+
+    where: {
+      slug: query.categorySlug
+    },
+
+    with: {
+      properties: {
+        columns: {
+          dataType: true,
+          id: true,
+          slug: true
+        },
+
+        with: {
+          enumOptions: {
+            columns: {
+              slug: true
+            }
+          }
+        }
+      }
+    }
+  })
+
+  if (metadata === undefined) {
+    throw createError({ status: 400, message: `Unknown equipment category: ${query.categorySlug}` })
+  }
+
+  return metadata
+}
+
+function addNumberConditions(
+  conditions: SQL[],
+  filters: ItemsListNumberFilter[],
+  propertiesBySlug: Map<string, CategoryMetadataProperty>
+) {
+  for (const filter of filters) {
+    const property = propertiesBySlug.get(filter.propertySlug)
+
+    if (property?.dataType !== 'number') {
+      throw createError({ status: 400, message: `Unknown numeric property: ${filter.propertySlug}` })
+    }
+
+    const valueConditions: SQL[] = []
+
+    if (filter.min !== null) {
+      valueConditions.push(gte(filterValues.valueNumber, String(filter.min)))
+    }
+
+    if (filter.max !== null) {
+      valueConditions.push(lte(filterValues.valueNumber, String(filter.max)))
+    }
+
+    conditions.push(createPropertyExistsCondition(property.id, valueConditions))
+  }
+}
+
+function groupEnumFilters(
+  filters: ItemsListEnumFilter[],
+  propertiesBySlug: Map<string, CategoryMetadataProperty>
+) : Map<number, EnumFilterGroup> {
+  const groups = new Map<number, EnumFilterGroup>()
+
+  for (const filter of filters) {
+    const property = propertiesBySlug.get(filter.propertySlug)
+
+    if (property?.dataType !== 'enum') {
+      throw createError({ status: 400, message: `Unknown enum property: ${filter.propertySlug}` })
+    }
+
+    const optionExists = property.enumOptions.some((option) => option.slug === filter.optionSlug)
+
+    if (!optionExists) {
+      throw createError({
+        status: 400,
+        message: `Unknown option ${filter.optionSlug} for property ${filter.propertySlug}`
+      })
+    }
+
+    const group = groups.get(property.id)
+
+    if (group === undefined) {
+      groups.set(property.id, { optionSlugs: [filter.optionSlug], propertyId: property.id })
+    } else {
+      group.optionSlugs.push(filter.optionSlug)
+    }
+  }
+
+  return groups
+}
+
+function addEnumConditions(conditions: SQL[], groups: Map<number, EnumFilterGroup>) {
+  for (const group of groups.values()) {
+    const optionCondition = or(
+      ...group.optionSlugs.map((optionSlug) => eq(filterValues.valueText, optionSlug))
+    )
+
+    if (optionCondition !== undefined) {
+      conditions.push(createPropertyExistsCondition(group.propertyId, [optionCondition]))
+    }
+  }
+}
+
+function addBooleanConditions(
+  conditions: SQL[],
+  filters: ItemsListBooleanFilter[],
+  propertiesBySlug: Map<string, CategoryMetadataProperty>
+) {
+  for (const filter of filters) {
+    const property = propertiesBySlug.get(filter.propertySlug)
+
+    if (property?.dataType !== 'boolean') {
+      throw createError({ status: 400, message: `Unknown boolean property: ${filter.propertySlug}` })
+    }
+
+    const valueCondition = eq(filterValues.valueBoolean, filter.value)
+    conditions.push(createPropertyExistsCondition(property.id, [valueCondition]))
+  }
+}
+
+function resolveSortPropertyId(
+  sort: ItemsListSort,
+  propertiesBySlug: Map<string, CategoryMetadataProperty>
+) : number | undefined {
+  if (!sort.startsWith('property:')) {
+    return undefined
+  }
+
+  const propertySlug = sort.slice('property:'.length)
+  const property = propertiesBySlug.get(propertySlug)
+
+  if (property?.dataType !== 'number') {
+    throw createError({ status: 400, message: `Unknown numeric sort property: ${propertySlug}` })
+  }
+
+  return property.id
+}
+
+function createOrderBy(query: ItemsListQuery, sortPropertyId: number | undefined) : SQL[] {
+  if (query.sort === 'brand') {
+    const brandOrder = query.direction === 'asc' ? asc(brands.name) : desc(brands.name)
+    return [brandOrder, asc(equipmentItems.name), asc(equipmentItems.id)]
+  }
+
+  if (sortPropertyId === undefined) {
+    const nameOrder = query.direction === 'asc' ? asc(equipmentItems.name) : desc(equipmentItems.name)
+    return [nameOrder, asc(equipmentItems.id)]
+  }
+
+  const propertyOrder = query.direction === 'asc'
+    ? sql`${catalogPropertySortValues.valueNumber} asc nulls last`
+    : sql`${catalogPropertySortValues.valueNumber} desc nulls last`
+
+  return [propertyOrder, asc(equipmentItems.name), asc(equipmentItems.id)]
+}
+
+/** Resolves category-aware filters into the shared list/count predicate and stable ordering. */
+async function buildCatalogListSql(dbHttp: DbHttp, query: ItemsListQuery) : Promise<CatalogListSql> {
+  const conditions = createBaseConditions(query)
+  const metadata = await loadCategoryMetadata(dbHttp, query)
+  const metadataProperties = metadata?.properties.map((property) => [property.slug, property] as const)
+  const propertiesBySlug = new Map(metadataProperties)
+
+  addNumberConditions(conditions, query.numberFilter, propertiesBySlug)
+  const enumGroups = groupEnumFilters(query.enumFilter, propertiesBySlug)
+  addEnumConditions(conditions, enumGroups)
+  addBooleanConditions(conditions, query.booleanFilter, propertiesBySlug)
+
+  const sortPropertyId = resolveSortPropertyId(query.sort, propertiesBySlug)
+
+  return {
+    orderBy: createOrderBy(query, sortPropertyId),
+    sortPropertyId,
+    where: and(...conditions)
+  }
+}
+
+export {
+  buildCatalogListSql,
+  catalogPropertySortValues
+}
+
+export type {
+  CatalogListBrand,
+  CatalogListCategory,
+  CatalogListItemRow,
+  CatalogListSql
+}

--- a/server/utils/equipment/property-values.ts
+++ b/server/utils/equipment/property-values.ts
@@ -1,0 +1,51 @@
+import { createError } from 'h3'
+
+type EquipmentPropertyDataType = 'boolean' | 'enum' | 'number' | 'text'
+type EquipmentPropertyValue = string | number | boolean | null
+
+interface EquipmentPropertyValueColumns {
+  dataType: EquipmentPropertyDataType;
+  valueBoolean: boolean | null;
+  valueNumber: string | null;
+  valueText: string | null;
+}
+
+function getEquipmentPropertyDataType(dataType: string): EquipmentPropertyDataType {
+  const isSupportedDataType = dataType === 'boolean'
+    || dataType === 'enum'
+    || dataType === 'number'
+    || dataType === 'text'
+
+  if (!isSupportedDataType) {
+    throw createError({
+      status: 500,
+      message: `Unsupported equipment property data type: ${dataType}`
+    })
+  }
+
+  return dataType
+}
+
+/** Normalizes the EAV value columns into the public equipment property value contract. */
+function normalizeEquipmentPropertyValue(input: EquipmentPropertyValueColumns): EquipmentPropertyValue {
+  if (input.dataType === 'number') {
+    return input.valueNumber === null ? null : Number(input.valueNumber)
+  }
+
+  if (input.dataType === 'boolean') {
+    return input.valueBoolean
+  }
+
+  return input.valueText
+}
+
+export {
+  getEquipmentPropertyDataType,
+  normalizeEquipmentPropertyValue
+}
+
+export type {
+  EquipmentPropertyDataType,
+  EquipmentPropertyValue,
+  EquipmentPropertyValueColumns
+}

--- a/server/utils/validation/__tests__/schemas.test.ts
+++ b/server/utils/validation/__tests__/schemas.test.ts
@@ -723,29 +723,218 @@ describe('validation schemas', () => {
   it('should normalize items list query', () => {
     const result = validateItemsListQuery({
       brandSlug: '  msr  ',
+      booleanFilter: 'freestanding:true',
       categorySlug: '  stoves  ',
+      direction: 'desc',
+      enumFilter: 'fuel-type:isobutane-propane',
       limit: '10',
+      numberFilter: 'weight:0.08:0.12',
       page: '2',
-      search: '  pocket rocket  '
+      search: '  pocket rocket  ',
+      sort: 'property:weight'
     })
 
     expect(result).toStrictEqual({
-      brandSlug: 'msr',
+      booleanFilter: [{
+        propertySlug: 'freestanding',
+        value: true
+      }],
+      brandSlug: ['msr'],
       categorySlug: 'stoves',
+      direction: 'desc',
+      enumFilter: [{
+        optionSlug: 'isobutane-propane',
+        propertySlug: 'fuel-type'
+      }],
       limit: 10,
+      numberFilter: [{
+        max: 0.12,
+        min: 0.08,
+        propertySlug: 'weight'
+      }],
       page: 2,
-      search: 'pocket rocket'
+      search: 'pocket rocket',
+      sort: 'property:weight'
     })
   })
 
-  it('should apply default pagination and empty filters for items list query', () => {
+  it('should apply defaults for items list query', () => {
     const result = validateItemsListQuery({})
 
     expect(result).toStrictEqual({
+      booleanFilter: [],
+      brandSlug: [],
+      direction: 'asc',
+      enumFilter: [],
       limit: 20,
+      numberFilter: [],
       page: 1,
-      search: ''
+      search: '',
+      sort: 'name'
     })
+  })
+
+  it('should deduplicate repeatable items list filters while preserving first occurrence order', () => {
+    const result = validateItemsListQuery({
+      booleanFilter: [
+        'freestanding:true',
+        'waterproof:false',
+        'freestanding:true'
+      ],
+      brandSlug: ['msr', 'sea-to-summit', 'msr', 'therm-a-rest'],
+      categorySlug: 'sleeping-bags',
+      enumFilter: [
+        'fill-type:down',
+        'fill-type:synthetic',
+        'fill-type:down',
+        'shell-material:nylon'
+      ],
+      numberFilter: [
+        'weight:1:2',
+        'comfort-temperature:-10:',
+        'weight:1.0:2.00'
+      ]
+    })
+
+    expect(result.brandSlug).toStrictEqual([
+      'msr',
+      'sea-to-summit',
+      'therm-a-rest'
+    ])
+    expect(result.numberFilter).toStrictEqual([{
+      max: 2,
+      min: 1,
+      propertySlug: 'weight'
+    }, {
+      max: null,
+      min: -10,
+      propertySlug: 'comfort-temperature'
+    }])
+    expect(result.enumFilter).toStrictEqual([{
+      optionSlug: 'down',
+      propertySlug: 'fill-type'
+    }, {
+      optionSlug: 'synthetic',
+      propertySlug: 'fill-type'
+    }, {
+      optionSlug: 'nylon',
+      propertySlug: 'shell-material'
+    }])
+    expect(result.booleanFilter).toStrictEqual([{
+      propertySlug: 'freestanding',
+      value: true
+    }, {
+      propertySlug: 'waterproof',
+      value: false
+    }])
+  })
+
+  it('should normalize open and equal numeric ranges', () => {
+    const result = validateItemsListQuery({
+      categorySlug: 'tents',
+      numberFilter: [
+        'minimum-temperature:-12.5:',
+        'weight::2.75',
+        'capacity:2:2'
+      ]
+    })
+
+    expect(result.numberFilter).toStrictEqual([{
+      max: null,
+      min: -12.5,
+      propertySlug: 'minimum-temperature'
+    }, {
+      max: 2.75,
+      min: null,
+      propertySlug: 'weight'
+    }, {
+      max: 2,
+      min: 2,
+      propertySlug: 'capacity'
+    }])
+  })
+
+  it('should normalize supported decimal filter spellings', () => {
+    const result = validateItemsListQuery({
+      categorySlug: 'tents',
+      numberFilter: [
+        'minimum-temperature:-0:',
+        'weight:.5:',
+        'capacity:1.:'
+      ]
+    })
+
+    expect(result.numberFilter).toStrictEqual([{
+      max: null,
+      min: 0,
+      propertySlug: 'minimum-temperature'
+    }, {
+      max: null,
+      min: 0.5,
+      propertySlug: 'weight'
+    }, {
+      max: null,
+      min: 1,
+      propertySlug: 'capacity'
+    }])
+  })
+
+  it.each([
+    { direction: 'asc', sort: 'name' },
+    { direction: 'desc', sort: 'brand' }
+  ])('should accept non-property sort: %j', ({ direction, sort }) => {
+    const result = validateItemsListQuery({
+      direction,
+      sort
+    })
+
+    expect(result.direction).toBe(direction)
+    expect(result.sort).toBe(sort)
+  })
+
+  it('should accept brand filters without a category', () => {
+    const result = validateItemsListQuery({
+      brandSlug: ['msr', 'primus']
+    })
+
+    expect(result.brandSlug).toStrictEqual(['msr', 'primus'])
+  })
+
+  it.each([
+    ['brandSlug', Array.from(
+      { length: limits.maxEquipmentItemsFilterCount + 1 },
+      (_value, index) => `brand-${index}`
+    )],
+    ['numberFilter', Array.from(
+      { length: limits.maxEquipmentItemsFilterCount + 1 },
+      (_value, index) => `number-${index}:1:2`
+    )],
+    ['enumFilter', Array.from(
+      { length: limits.maxEquipmentItemsFilterCount + 1 },
+      (_value, index) => `enum-${index}:option-${index}`
+    )],
+    ['booleanFilter', Array.from(
+      { length: limits.maxEquipmentItemsFilterCount + 1 },
+      (_value, index) => `boolean-${index}:true`
+    )]
+  ])('should reject too many %s values', (filterName, values) => {
+    expect(() => validateItemsListQuery({
+      categorySlug: 'tents',
+      [filterName]: values
+    })).toThrow(/./u)
+  })
+
+  it('should reject too many property filters across filter types', () => {
+    const numberFilter = Array.from({ length: 7 }, (_value, index) => `number-${index}:1:2`)
+    const enumFilter = Array.from({ length: 7 }, (_value, index) => `enum-${index}:option-${index}`)
+    const booleanFilter = Array.from({ length: 7 }, (_value, index) => `boolean-${index}:true`)
+
+    expect(() => validateItemsListQuery({
+      booleanFilter,
+      categorySlug: 'tents',
+      enumFilter,
+      numberFilter
+    })).toThrow(/property filters/u)
   })
 
   it('should clamp too-large items list limits to the shared maximum', () => {
@@ -754,14 +943,114 @@ describe('validation schemas', () => {
     })
 
     expect(result).toStrictEqual({
+      booleanFilter: [],
+      brandSlug: [],
+      direction: 'asc',
+      enumFilter: [],
       limit: 100,
+      numberFilter: [],
       page: 1,
-      search: ''
+      search: '',
+      sort: 'name'
     })
   })
 
-  it.each([{ page: 'abc' }, { page: '0' }, { limit: '0' }, { page: ['1'] }])('should reject malformed items list query: %j', (query) => {
+  it.each([
+    { page: 'abc' },
+    { page: '0' },
+    { limit: '0' },
+    { page: ['1'] },
+    { direction: 'sideways' },
+    { brandSlug: 'MSR' },
+    { categorySlug: 'Sleeping-Bags' },
+    { brandSlug: ['msr', 42] }
+  ])('should reject malformed items list query: %j', (query) => {
     expect(() => validateItemsListQuery(query)).toThrow(/./u)
+  })
+
+  it.each([
+    'weight',
+    'weight:1',
+    'weight:1:2:3',
+    'weight::',
+    'weight:two:3',
+    'weight:1e2:200',
+    'weight:NaN:3',
+    'weight:1:Infinity',
+    'weight:3:2',
+    'Weight:1:2',
+    'packed_weight:1:2'
+  ])('should reject malformed number filter: %s', (numberFilter) => {
+    expect(() => validateItemsListQuery({
+      categorySlug: 'sleeping-bags',
+      numberFilter
+    })).toThrow(/./u)
+  })
+
+  it.each([
+    'fill-type',
+    'fill-type:',
+    ':down',
+    'fill-type:down:extra',
+    'Fill-Type:down',
+    'fill-type:synthetic_fill'
+  ])('should reject malformed enum filter: %s', (enumFilter) => {
+    expect(() => validateItemsListQuery({
+      categorySlug: 'sleeping-bags',
+      enumFilter
+    })).toThrow(/./u)
+  })
+
+  it.each([
+    'freestanding',
+    'freestanding:',
+    ':true',
+    'freestanding:TRUE',
+    'freestanding:1',
+    'freestanding:true:extra',
+    'FreeStanding:true'
+  ])('should reject malformed boolean filter: %s', (booleanFilter) => {
+    expect(() => validateItemsListQuery({
+      booleanFilter,
+      categorySlug: 'tents'
+    })).toThrow(/./u)
+  })
+
+  it.each([
+    '',
+    'price',
+    'property:',
+    'property:Weight',
+    'property:packed_weight',
+    'property:weight:extra'
+  ])('should reject malformed items list sort: %s', (sort) => {
+    expect(() => validateItemsListQuery({
+      categorySlug: 'sleeping-bags',
+      sort
+    })).toThrow(/./u)
+  })
+
+  it.each([
+    { numberFilter: 'weight::2' },
+    { enumFilter: 'fill-type:down' },
+    { booleanFilter: 'freestanding:true' },
+    { sort: 'property:weight' }
+  ])('should require category slug for category-dependent query: %j', (query) => {
+    expect(() => validateItemsListQuery(query)).toThrow(/categorySlug/u)
+  })
+
+  it('should reject different number ranges for one property', () => {
+    expect(() => validateItemsListQuery({
+      categorySlug: 'sleeping-bags',
+      numberFilter: ['weight:1:2', 'weight:1:3']
+    })).toThrow(/numberFilter/u)
+  })
+
+  it('should reject different boolean values for one property', () => {
+    expect(() => validateItemsListQuery({
+      booleanFilter: ['freestanding:true', 'freestanding:false'],
+      categorySlug: 'tents'
+    })).toThrow(/booleanFilter/u)
   })
 
   it('should accept canonical uuid v7 item ids only', () => {

--- a/server/utils/validation/schemas.ts
+++ b/server/utils/validation/schemas.ts
@@ -34,13 +34,6 @@ const referenceDataSlugSchema = v.pipe(
   v.regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u)
 )
 
-const optionalFilterQuerySchema = v.optional(
-  v.pipe(
-    trimmedStringSchema,
-    v.transform((value) => value === '' ? undefined : value)
-  )
-)
-
 const limitQuerySchema = v.pipe(
   v.optional(v.string(), '20'),
   v.digits(),
@@ -275,13 +268,295 @@ const packingListAvailableGearQuerySchema = v.object({
   )
 })
 
-const itemsListQuerySchema = v.object({
-  brandSlug: optionalFilterQuerySchema,
-  categorySlug: optionalFilterQuerySchema,
-  limit: limitQuerySchema,
-  page: pageQuerySchema,
-  search: v.optional(trimmedStringSchema, '')
-})
+interface ItemsListNumberFilter {
+  max: number | null;
+  min: number | null;
+  propertySlug: string;
+}
+
+interface ItemsListEnumFilter {
+  optionSlug: string;
+  propertySlug: string;
+}
+
+interface ItemsListBooleanFilter {
+  propertySlug: string;
+  value: boolean;
+}
+
+type ItemsListSort = 'brand' | 'name' | `property:${string}`
+
+const decimalNumberPattern = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/u
+
+const brandFilterSlugSchema = v.pipe(
+  referenceDataSlugSchema,
+  v.maxLength(limits.maxBrandSlugLength)
+)
+
+const categoryFilterSlugSchema = v.pipe(
+  referenceDataSlugSchema,
+  v.maxLength(limits.maxEquipmentCategorySlugLength)
+)
+
+const categoryPropertyFilterSlugSchema = v.pipe(
+  referenceDataSlugSchema,
+  v.maxLength(limits.maxCategoryPropertySlugLength)
+)
+
+const propertyEnumOptionFilterSlugSchema = v.pipe(
+  referenceDataSlugSchema,
+  v.maxLength(limits.maxPropertyEnumOptionSlugLength)
+)
+
+const numberFilterFormatMessage = 'numberFilter must use <property-slug>:<min-or-empty>:<max-or-empty>'
+
+const decimalFilterBoundSchema = v.union([
+  v.pipe(
+    v.literal(''),
+    v.transform(() => null)
+  ),
+
+  v.pipe(
+    v.string(),
+    v.regex(decimalNumberPattern),
+    v.toNumber(),
+    v.finite(),
+    v.transform((value) => Object.is(value, -0) ? 0 : value)
+  )
+])
+
+const numberFilterQueryValueSchema = v.pipe(
+  trimmedNonEmptyStringSchema,
+  v.transform((value) => value.split(':')),
+  v.strictTuple([
+    categoryPropertyFilterSlugSchema,
+    decimalFilterBoundSchema,
+    decimalFilterBoundSchema
+  ], numberFilterFormatMessage),
+  v.check(([, min, max]) => min !== null || max !== null, numberFilterFormatMessage),
+  v.check(([, min, max]) => min === null || max === null || min <= max, numberFilterFormatMessage),
+  v.transform(([propertySlug, min, max]): ItemsListNumberFilter => {
+    return {
+      max,
+      min,
+      propertySlug
+    }
+  })
+)
+
+const enumFilterQueryValueSchema = v.pipe(
+  trimmedNonEmptyStringSchema,
+  v.transform((value) => value.split(':')),
+  v.strictTuple([
+    categoryPropertyFilterSlugSchema,
+    propertyEnumOptionFilterSlugSchema
+  ], 'enumFilter must use <property-slug>:<option-slug>'),
+  v.transform(([propertySlug, optionSlug]): ItemsListEnumFilter => {
+    return {
+      optionSlug,
+      propertySlug
+    }
+  })
+)
+
+const booleanFilterQueryValueSchema = v.pipe(
+  trimmedNonEmptyStringSchema,
+  v.transform((value) => value.split(':')),
+  v.strictTuple([
+    categoryPropertyFilterSlugSchema,
+    v.picklist(['true', 'false'])
+  ], 'booleanFilter must use <property-slug>:true|false'),
+  v.transform(([propertySlug, value]): ItemsListBooleanFilter => {
+    return {
+      propertySlug,
+      value: value === 'true'
+    }
+  })
+)
+
+const propertySortPrefix = 'property:'
+const propertyItemsListSortSchema = v.pipe(
+  v.string(),
+  v.startsWith(propertySortPrefix),
+  v.transform((value) => value.slice(propertySortPrefix.length)),
+  categoryPropertyFilterSlugSchema,
+  v.transform((propertySlug): ItemsListSort => `property:${propertySlug}`)
+)
+
+const itemsListSortSchema = v.pipe(
+  v.optional(trimmedNonEmptyStringSchema, 'name'),
+  v.union([
+    v.picklist(['name', 'brand']),
+    propertyItemsListSortSchema
+  ], 'sort must be name, brand, or property:<property-slug>')
+)
+
+function deduplicateByKey<TValue>(values: TValue[], getKey: (value: TValue) => string): TValue[] {
+  const seenKeys = new Set<string>()
+  const uniqueValues: TValue[] = []
+
+  for (const value of values) {
+    const key = getKey(value)
+
+    if (!seenKeys.has(key)) {
+      seenKeys.add(key)
+      uniqueValues.push(value)
+    }
+  }
+
+  return uniqueValues
+}
+
+function getNumberFilterKey(filter: ItemsListNumberFilter): string {
+  return `${filter.propertySlug}:${filter.min ?? ''}:${filter.max ?? ''}`
+}
+
+function getEnumFilterKey(filter: ItemsListEnumFilter): string {
+  return `${filter.propertySlug}:${filter.optionSlug}`
+}
+
+function getBooleanFilterKey(filter: ItemsListBooleanFilter): string {
+  return `${filter.propertySlug}:${filter.value}`
+}
+
+function hasConflictingNumberFilters(filters: ItemsListNumberFilter[]): boolean {
+  const filtersByProperty = new Map<string, ItemsListNumberFilter>()
+
+  for (const filter of filters) {
+    const existingFilter = filtersByProperty.get(filter.propertySlug)
+
+    if (existingFilter === undefined) {
+      filtersByProperty.set(filter.propertySlug, filter)
+    } else {
+      const hasDifferentMin = existingFilter.min !== filter.min
+      const hasDifferentMax = existingFilter.max !== filter.max
+
+      if (hasDifferentMin || hasDifferentMax) {
+        return true
+      }
+    }
+  }
+
+  return false
+}
+
+function hasConflictingBooleanFilters(filters: ItemsListBooleanFilter[]): boolean {
+  const valuesByProperty = new Map<string, boolean>()
+
+  for (const filter of filters) {
+    const existingValue = valuesByProperty.get(filter.propertySlug)
+
+    if (existingValue === undefined) {
+      valuesByProperty.set(filter.propertySlug, filter.value)
+    } else if (existingValue !== filter.value) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const brandSlugListQuerySchema = v.pipe(
+  v.optional(v.union([
+    brandFilterSlugSchema,
+    v.pipe(
+      v.array(brandFilterSlugSchema),
+      v.maxLength(limits.maxEquipmentItemsFilterCount)
+    )
+  ]), []),
+  v.transform((value) => {
+    const values = Array.isArray(value) ? value : [value]
+    const uniqueValues = new Set(values)
+
+    return [...uniqueValues]
+  })
+)
+
+const numberFilterListQuerySchema = v.pipe(
+  v.optional(v.union([
+    numberFilterQueryValueSchema,
+    v.pipe(
+      v.array(numberFilterQueryValueSchema),
+      v.maxLength(limits.maxEquipmentItemsFilterCount)
+    )
+  ]), []),
+  v.transform((value) => {
+    const values = Array.isArray(value) ? value : [value]
+
+    return deduplicateByKey(values, getNumberFilterKey)
+  })
+)
+
+const enumFilterListQuerySchema = v.pipe(
+  v.optional(v.union([
+    enumFilterQueryValueSchema,
+    v.pipe(
+      v.array(enumFilterQueryValueSchema),
+      v.maxLength(limits.maxEquipmentItemsFilterCount)
+    )
+  ]), []),
+  v.transform((value) => {
+    const values = Array.isArray(value) ? value : [value]
+
+    return deduplicateByKey(values, getEnumFilterKey)
+  })
+)
+
+const booleanFilterListQuerySchema = v.pipe(
+  v.optional(v.union([
+    booleanFilterQueryValueSchema,
+    v.pipe(
+      v.array(booleanFilterQueryValueSchema),
+      v.maxLength(limits.maxEquipmentItemsFilterCount)
+    )
+  ]), []),
+  v.transform((value) => {
+    const values = Array.isArray(value) ? value : [value]
+
+    return deduplicateByKey(values, getBooleanFilterKey)
+  })
+)
+
+const itemsListQuerySchema = v.pipe(
+  v.object({
+    booleanFilter: booleanFilterListQuerySchema,
+    brandSlug: brandSlugListQuerySchema,
+    categorySlug: v.optional(categoryFilterSlugSchema),
+    direction: v.optional(v.picklist(['asc', 'desc']), 'asc'),
+    enumFilter: enumFilterListQuerySchema,
+    limit: limitQuerySchema,
+    numberFilter: numberFilterListQuerySchema,
+    page: pageQuerySchema,
+    search: v.optional(trimmedStringSchema, ''),
+    sort: itemsListSortSchema
+  }),
+  v.check((query) => {
+    const hasConflict = hasConflictingNumberFilters(query.numberFilter)
+
+    return !hasConflict
+  }, 'numberFilter cannot contain different ranges for one property'),
+  v.check((query) => {
+    const hasConflict = hasConflictingBooleanFilters(query.booleanFilter)
+
+    return !hasConflict
+  }, 'booleanFilter cannot contain different values for one property'),
+  v.check((query) => {
+    const propertyFilterCount = query.numberFilter.length
+      + query.enumFilter.length
+      + query.booleanFilter.length
+
+    return propertyFilterCount <= limits.maxEquipmentItemsFilterCount
+  }, `property filters cannot contain more than ${limits.maxEquipmentItemsFilterCount} values`),
+  v.check((query) => {
+    const hasPropertyFilters = query.numberFilter.length > 0
+      || query.enumFilter.length > 0
+      || query.booleanFilter.length > 0
+    const hasPropertySort = query.sort.startsWith('property:')
+    const requiresCategory = hasPropertyFilters || hasPropertySort
+
+    return !requiresCategory || query.categorySlug !== undefined
+  }, 'categorySlug is required for property filters and sorting')
+)
 
 const redirectTargetQuerySchema = v.object({
   redirectTo: v.pipe(
@@ -460,4 +735,11 @@ export {
   validateTwitchOAuthBody,
   validateUserEquipmentCreateBody,
   validateUserEquipmentIdParams
+}
+
+export type {
+  ItemsListBooleanFilter,
+  ItemsListEnumFilter,
+  ItemsListNumberFilter,
+  ItemsListSort
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -10,6 +10,7 @@ const limits = {
   maxEquipmentCategorySlugLength: 128,
   maxEquipmentGroupNameLength: 64,
   maxEquipmentGroupSlugLength: 128,
+  maxEquipmentItemsFilterCount: 20,
   maxPackingListEntryCustomNameLength: 128,
   maxPackingListNameLength: 128,
   maxPaginatedListLimit: 100,

--- a/tests/playwright/gear-library/gear-library-entry-list.test.ts
+++ b/tests/playwright/gear-library/gear-library-entry-list.test.ts
@@ -11,6 +11,17 @@ interface GearLibraryListItem {
   category: GearLibraryEntitySummary;
   id: string;
   name: string;
+  properties: EquipmentProperty[];
+}
+
+type EquipmentPropertyDataType = 'boolean' | 'enum' | 'number' | 'text'
+
+interface EquipmentProperty {
+  dataType: EquipmentPropertyDataType;
+  name: string;
+  slug: string;
+  unit: string | null;
+  value: string | number | boolean | null;
 }
 
 interface GearLibraryItemsResponse {
@@ -33,7 +44,9 @@ const firstPageResponse: GearLibraryItemsResponse = {
     category: {
       name: 'Stoves',
       slug: 'stoves'
-    }
+    },
+
+    properties: []
   }, {
     id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477da',
     name: 'NeoAir XLite NXT',
@@ -46,7 +59,9 @@ const firstPageResponse: GearLibraryItemsResponse = {
     category: {
       name: 'Sleeping Pads',
       slug: 'sleeping-pads'
-    }
+    },
+
+    properties: []
   }],
   limit: 2,
   page: 1,
@@ -66,7 +81,9 @@ const secondPageResponse: GearLibraryItemsResponse = {
     category: {
       name: 'Stoves',
       slug: 'stoves'
-    }
+    },
+
+    properties: []
   }],
   limit: 2,
   page: 2,

--- a/tests/playwright/gear-library/gear-library-my-gear.test.ts
+++ b/tests/playwright/gear-library/gear-library-my-gear.test.ts
@@ -15,6 +15,7 @@ interface GearLibraryListItem {
   category: GearLibraryEntitySummary;
   id: string;
   name: string;
+  properties: EquipmentProperty[];
 }
 
 interface GearLibraryItemsResponse {
@@ -24,12 +25,14 @@ interface GearLibraryItemsResponse {
   total: number;
 }
 
-interface ItemDetailProperty {
-  dataType: string;
+type EquipmentPropertyDataType = 'boolean' | 'enum' | 'number' | 'text'
+
+interface EquipmentProperty {
+  dataType: EquipmentPropertyDataType;
   name: string;
   slug: string;
   unit: string | null;
-  value: string | null;
+  value: string | number | boolean | null;
 }
 
 interface ItemDetailResponse {
@@ -38,8 +41,7 @@ interface ItemDetailResponse {
   createdAt: string;
   id: string;
   name: string;
-  properties: ItemDetailProperty[];
-  status: string;
+  properties: EquipmentProperty[];
 }
 
 interface MyGearItem {
@@ -71,7 +73,21 @@ const gearLibraryItemsResponse: GearLibraryItemsResponse = {
     category: {
       name: 'Stoves',
       slug: 'stoves'
-    }
+    },
+
+    properties: [{
+      dataType: 'number',
+      name: 'Weight',
+      slug: 'weight',
+      unit: 'g',
+      value: 83
+    }, {
+      dataType: 'boolean',
+      name: 'Piezo',
+      slug: 'piezo',
+      unit: null,
+      value: true
+    }]
   }],
   limit: 20,
   page: 1,
@@ -87,15 +103,14 @@ const itemDetailResponse: ItemDetailResponse = {
     name: 'Weight',
     slug: 'weight',
     unit: 'g',
-    value: '83'
+    value: 83
   }, {
     dataType: 'boolean',
     name: 'Piezo',
     slug: 'piezo',
     unit: null,
-    value: 'true'
+    value: true
   }],
-  status: 'approved',
 
   brand: {
     id: 1,
@@ -259,6 +274,7 @@ test.describe('Gear library my gear flow', () => {
     await expect(page).toHaveURL(new RegExp(`/gear-library/${itemId}$`, 'u'))
     await expect(page.getByRole('heading', { level: 1, name: 'PocketRocket Deluxe' })).toBeVisible()
     await expect(page.getByText('83 g')).toBeVisible()
+    await expect(page.getByText('Yes', { exact: true })).toBeVisible()
     const addButton = page.getByRole('button', { name: 'Save to my gear' })
     await expect(addButton).toBeVisible()
     await expect(page.getByRole('link', { name: 'View my gear' })).toBeVisible()


### PR DESCRIPTION
## Summary

Turns the equipment catalog read API into a research-ready contract while keeping the EAV details on the server where they belong 🧭😎

- 🔎 Add category-aware number, enum, boolean, brand, and text-search filters with the documented OR/AND behavior
- 📊 Add stable name, brand, and numeric-property sorting with inclusive bounds and missing values placed last
- 🧩 Enrich catalog rows with three ordered key properties and return ordered, typed values from item detail
- 🔒 Hide pending and rejected items from public detail reads, remove public status, and cap repeatable filters
- 🧠 Express composite query validation through typed Valibot pipelines while preserving conflict checks
- ✅ Expand schema, handler, SQL-shape, and browser-flow coverage for the new contract

## Motivation

The catalog frontend should consume one predictable server-owned representation instead of rebuilding EAV rules in the browser 🛠️✨ This keeps filtering, ordering, visibility, and value normalization consistent across list and detail reads.

## Performance Impact

- ⚡ Property filters use non-multiplying EXISTS predicates, keeping pagination rows stable
- 🚀 List enrichment loads definitions and values in bounded batch queries instead of per-item requests
- 🛡️ Repeatable filter limits prevent oversized SQL condition trees

## Breaking Changes

- Public item detail no longer returns status
- Numeric and boolean property values are returned as their native JSON types instead of strings

## Related Issues

Fixes #679
Supports #677