### PR TITLE
Add mobile bottom-sheet dialog presentation

### DIFF
--- a/app/components/dialogs/ModalDialog.vue
+++ b/app/components/dialogs/ModalDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <dialog
     ref="dialogRef"
-    :class="$style.dialog"
+    :class="[$style.component, { isBottomSheet }]"
     @cancel="handleCancel"
   >
     <slot />
@@ -9,41 +9,82 @@
 </template>
 
 <script lang="ts" setup>
-  import { useTemplateRef, watchEffect } from 'vue'
+  import { computed, useTemplateRef, watchEffect } from 'vue'
   import { useEventListener } from '@vueuse/core'
 
   interface Props {
     closeDisabled?: boolean;
+    mobilePresentation?: 'bottom-sheet' | 'centered';
   }
 
-  const { closeDisabled = false } = defineProps<Props>()
+  const {
+    closeDisabled,
+    mobilePresentation = 'centered'
+  } = defineProps<Props>()
+
   const dialogRef = useTemplateRef('dialogRef')
+  let invokingElement: HTMLElement | null = null
 
   const isOpened = defineModel<boolean>({
     required: true
   })
 
+  const isBottomSheet = computed(() => mobilePresentation === 'bottom-sheet')
+
   watchEffect(() => {
+    const dialog = dialogRef.value
+
+    if (dialog === null) {
+      return
+    }
+
     if (isOpened.value) {
-      dialogRef.value?.showModal()
-    } else {
-      dialogRef.value?.close()
+      if (dialog.open) {
+        return
+      }
+
+      const { activeElement } = dialog.ownerDocument
+
+      invokingElement = activeElement instanceof globalThis.HTMLElement ? activeElement : null
+      dialog.showModal()
+
+      return
+    }
+
+    if (dialog.open) {
+      dialog.close()
     }
   })
 
   useEventListener(dialogRef, 'close', () => {
+    const elementToRestore = invokingElement
+
+    invokingElement = null
     isOpened.value = false
+
+    if (elementToRestore?.isConnected === true) {
+      elementToRestore.focus()
+    }
   })
 
-  // Close the dialog when clicking outside of it
-  useEventListener(dialogRef, 'click', ({ target }: MouseEvent) => {
-    if (closeDisabled) {
+  useEventListener(dialogRef, 'click', (event: MouseEvent) => {
+    const dialog = dialogRef.value
+
+    if (dialog === null || event.target !== dialog) {
       return
     }
 
-    if (target === dialogRef.value) {
-      dialogRef.value?.close()
+    // Safari lacks closedby="any", and ::backdrop is not a DOM event target.
+    // Backdrop clicks must therefore be distinguished using the dialog bounds.
+    const bounds = dialog.getBoundingClientRect()
+    const isWithinInlineBounds = event.clientX >= bounds.left && event.clientX <= bounds.right
+    const isWithinBlockBounds = event.clientY >= bounds.top && event.clientY <= bounds.bottom
+
+    if (isWithinInlineBounds && isWithinBlockBounds) {
+      return
     }
+
+    dialog.requestClose()
   })
 
   function handleCancel(event: Event) {
@@ -54,13 +95,15 @@
 </script>
 
 <style module>
-  .dialog {
+  .component {
+    --dialog-closed-translate: 0.75rem;
+
     padding: 0;
     border: none;
     background: none;
 
     opacity: 0;
-    translate: 0 0.75rem;
+    translate: 0 var(--dialog-closed-translate);
     transition:
       opacity var(--transition-duration-normal) var(--transition-easing-standard),
       translate var(--transition-duration-normal) var(--transition-easing-standard),
@@ -73,7 +116,29 @@
 
       @starting-style {
         opacity: 0;
-        translate: 0 0.75rem;
+        translate: 0 var(--dialog-closed-translate);
+      }
+    }
+
+    &:global(.isBottomSheet) {
+      @media (width < 900px) {
+        --dialog-closed-translate: 100%;
+
+        position: fixed;
+        inset-block: auto 0;
+        inset-inline: 0;
+        inline-size: 100%;
+        max-inline-size: none;
+        max-block-size: 90dvb;
+        margin: 0;
+        overflow: auto;
+        overscroll-behavior: contain;
+        scrollbar-gutter: stable;
+        padding-block-end: var(--layout-safe-bottom);
+        border-start-start-radius: var(--border-radius-24);
+        border-start-end-radius: var(--border-radius-24);
+        background-color: var(--color-surface-primary);
+        box-shadow: var(--shadow-large);
       }
     }
 
@@ -95,7 +160,7 @@
   }
 
   @starting-style {
-    .dialog {
+    .component {
       &[open] {
         &::backdrop {
           background-color: transparent;
@@ -106,11 +171,11 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .dialog {
-      translate: 0;
+    .component {
+      --dialog-closed-translate: 0;
 
-      &[open] {
-        translate: 0;
+      &:global(.isBottomSheet) {
+        --dialog-closed-translate: 0;
       }
     }
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto'
 import { basename } from 'node:path'
+import { env } from 'node:process'
+import { fileURLToPath } from 'node:url'
 
 type ComponentType = 'page' | 'layout' | 'component';
 
@@ -7,6 +9,10 @@ const customElements = new Set([
   'search',
   'selectedoption'
 ]);
+
+const modalDialogFixturePath = fileURLToPath(
+  new globalThis.URL('tests/nuxt/ModalDialog.vue', import.meta.url)
+)
 
 function getComponentType(filePath: string) : ComponentType {
   if (filePath.includes('/app/pages/')) {
@@ -99,6 +105,20 @@ export default defineNuxtConfig({
 
   imports: {
     autoImport: false
+  },
+
+  hooks: {
+    'pages:extend': (pages) => {
+      if (env.PERD_E2E_PAGES !== 'true') {
+        return
+      }
+
+      pages.push({
+        file: modalDialogFixturePath,
+        name: 'e2e-modal-dialog',
+        path: '/__e2e/modal-dialog'
+      })
+    }
   },
 
   nitro: {

--- a/tests/nuxt/ModalDialog.vue
+++ b/tests/nuxt/ModalDialog.vue
@@ -1,0 +1,215 @@
+<template>
+  <main :class="$style.component">
+    <h1 :class="$style.heading">
+      Modal dialog browser fixtures
+    </h1>
+
+    <div :class="$style.actions">
+      <PerdButton @click="openCenteredDialog">
+        Open centered dialog
+      </PerdButton>
+
+      <PerdButton @click="openBottomSheet">
+        Open bottom sheet
+      </PerdButton>
+
+      <PerdButton @click="openLongBottomSheet">
+        Open long bottom sheet
+      </PerdButton>
+
+      <PerdButton @click="openLockedBottomSheet">
+        Open locked bottom sheet
+      </PerdButton>
+    </div>
+
+    <ModalDialog
+      v-model="centeredOpened"
+      aria-labelledby="centered-dialog-title"
+    >
+      <section :class="$style.centeredSurface">
+        <h2 id="centered-dialog-title">
+          Centered dialog
+        </h2>
+
+        <PerdButton @click="closeCenteredDialog">
+          Close centered dialog
+        </PerdButton>
+      </section>
+    </ModalDialog>
+
+    <ModalDialog
+      v-model="bottomSheetOpened"
+      aria-labelledby="bottom-sheet-title"
+      mobile-presentation="bottom-sheet"
+    >
+      <section :class="$style.sheetSurface">
+        <h2 id="bottom-sheet-title">
+          Bottom sheet
+        </h2>
+
+        <label for="bottom-sheet-filter">
+          Filter name
+        </label>
+
+        <input id="bottom-sheet-filter" :class="$style.input" name="filter">
+
+        <PerdButton @click="closeBottomSheet">
+          Close bottom sheet
+        </PerdButton>
+      </section>
+    </ModalDialog>
+
+    <ModalDialog
+      v-model="longBottomSheetOpened"
+      aria-labelledby="long-bottom-sheet-title"
+      mobile-presentation="bottom-sheet"
+    >
+      <section :class="[$style.sheetSurface, 'isLong']">
+        <h2 id="long-bottom-sheet-title">
+          Long bottom sheet
+        </h2>
+
+        <label for="long-bottom-sheet-filter">
+          Filter name
+        </label>
+
+        <input id="long-bottom-sheet-filter" :class="$style.input" name="filter">
+
+        <div :class="$style.spacer" aria-hidden="true" />
+
+        <PerdButton @click="closeLongBottomSheet">
+          Close long bottom sheet
+        </PerdButton>
+      </section>
+    </ModalDialog>
+
+    <ModalDialog
+      v-model="lockedBottomSheetOpened"
+      aria-labelledby="locked-bottom-sheet-title"
+      close-disabled
+      mobile-presentation="bottom-sheet"
+    >
+      <section :class="$style.sheetSurface">
+        <h2 id="locked-bottom-sheet-title">
+          Locked bottom sheet
+        </h2>
+
+        <p>
+          Escape and backdrop dismiss are disabled.
+        </p>
+
+        <PerdButton @click="completeLockedBottomSheet">
+          Complete locked bottom sheet
+        </PerdButton>
+      </section>
+    </ModalDialog>
+  </main>
+</template>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+  import { definePageMeta } from '#imports'
+  import PerdButton from '~/components/PerdButton.vue'
+  import ModalDialog from '~/components/dialogs/ModalDialog.vue'
+
+  definePageMeta({
+    layout: false,
+    skipAuth: true
+  })
+
+  const centeredOpened = ref(false)
+  const bottomSheetOpened = ref(false)
+  const longBottomSheetOpened = ref(false)
+  const lockedBottomSheetOpened = ref(false)
+
+  function openCenteredDialog() {
+    centeredOpened.value = true
+  }
+
+  function closeCenteredDialog() {
+    centeredOpened.value = false
+  }
+
+  function openBottomSheet() {
+    bottomSheetOpened.value = true
+  }
+
+  function closeBottomSheet() {
+    bottomSheetOpened.value = false
+  }
+
+  function openLongBottomSheet() {
+    longBottomSheetOpened.value = true
+  }
+
+  function closeLongBottomSheet() {
+    longBottomSheetOpened.value = false
+  }
+
+  function openLockedBottomSheet() {
+    lockedBottomSheetOpened.value = true
+  }
+
+  function completeLockedBottomSheet() {
+    lockedBottomSheetOpened.value = false
+  }
+</script>
+
+<style module>
+  .component {
+    display: grid;
+    align-content: start;
+    gap: var(--spacing-24);
+    min-block-size: 100dvh;
+    padding: var(--spacing-24);
+    background-color: var(--color-background-page);
+  }
+
+  .heading {
+    font-size: var(--font-size-30);
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-16);
+  }
+
+  .centeredSurface,
+  .sheetSurface {
+    display: grid;
+    gap: var(--spacing-16);
+    inline-size: min(100vw - var(--spacing-32), 30rem);
+    padding: var(--spacing-24);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--border-radius-24);
+    background-color: var(--color-surface-primary);
+    box-shadow: var(--shadow-large);
+  }
+
+  .sheetSurface {
+    &:global(.isLong) {
+      min-block-size: 42rem;
+    }
+
+    @media (width < 900px) {
+      inline-size: 100%;
+      border: none;
+      border-radius: inherit;
+      box-shadow: none;
+    }
+  }
+
+  .input {
+    min-block-size: var(--layout-button-height-medium);
+    padding-inline: var(--spacing-12);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--layout-button-radius-small);
+    background-color: var(--color-background-elevated);
+    color: var(--color-text-primary);
+  }
+
+  .spacer {
+    min-block-size: 24rem;
+  }
+</style>

--- a/tests/playwright/dialogs/modal-dialog.test.ts
+++ b/tests/playwright/dialogs/modal-dialog.test.ts
@@ -1,0 +1,269 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect, test } from '../fixtures/global.fixtures.ts'
+
+interface ElementBox {
+  blockStart: number;
+  height: number;
+  inlineStart: number;
+  width: number;
+}
+
+const fixturePath = '/__e2e/modal-dialog'
+
+async function getElementBox(locator: Locator): Promise<ElementBox> {
+  const box = await locator.boundingBox()
+
+  if (box === null) {
+    throw new Error('Expected element to have a bounding box')
+  }
+
+  return {
+    blockStart: box.y,
+    height: box.height,
+    inlineStart: box.x,
+    width: box.width
+  }
+}
+
+async function waitForDialogTransition(dialog: Locator): Promise<void> {
+  await expect(dialog).toBeVisible()
+
+  await expect.poll(
+    async () => dialog.evaluate((element) => globalThis.getComputedStyle(element).opacity)
+  ).toBe('1')
+}
+
+function getViewportSize(page: Page) {
+  const viewport = page.viewportSize()
+
+  if (viewport === null) {
+    throw new Error('Expected page to have a viewport')
+  }
+
+  return viewport
+}
+
+async function expectCentered(dialog: Locator, page: Page): Promise<void> {
+  const box = await getElementBox(dialog)
+  const viewport = getViewportSize(page)
+  const dialogInlineCenter = box.inlineStart + box.width / 2
+  const dialogBlockCenter = box.blockStart + box.height / 2
+  const viewportInlineCenter = viewport.width / 2
+  const viewportBlockCenter = viewport.height / 2
+  const inlineOffset = Math.abs(dialogInlineCenter - viewportInlineCenter)
+  const blockOffset = Math.abs(dialogBlockCenter - viewportBlockCenter)
+
+  expect(inlineOffset).toBeLessThan(2)
+  expect(blockOffset).toBeLessThan(2)
+}
+
+async function expectBottomAnchored(dialog: Locator, page: Page): Promise<ElementBox> {
+  const box = await getElementBox(dialog)
+  const viewport = getViewportSize(page)
+  const bottomOffset = Math.abs(box.blockStart + box.height - viewport.height)
+
+  expect(bottomOffset).toBeLessThan(2)
+
+  return box
+}
+
+test.describe('Modal dialog', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(fixturePath)
+  })
+
+  test('should keep default and opted-in presentations centered on desktop', async ({ page }) => {
+    const centeredOpener = page.getByRole('button', { name: 'Open centered dialog' })
+
+    await centeredOpener.focus()
+    await page.keyboard.press('Enter')
+
+    const centeredDialog = page.getByRole('dialog', { name: 'Centered dialog' })
+
+    await waitForDialogTransition(centeredDialog)
+    await expectCentered(centeredDialog, page)
+    await page.getByRole('button', { name: 'Close centered dialog' }).click()
+    await expect(centeredDialog).toHaveCount(0)
+    await expect(centeredOpener).toBeFocused()
+
+    const bottomSheetOpener = page.getByRole('button', { name: 'Open bottom sheet' })
+
+    await bottomSheetOpener.focus()
+    await page.keyboard.press('Enter')
+
+    const bottomSheetDialog = page.getByRole('dialog', { name: 'Bottom sheet' })
+
+    await waitForDialogTransition(bottomSheetDialog)
+    await expectCentered(bottomSheetDialog, page)
+    await page.getByRole('button', { name: 'Close bottom sheet' }).click()
+    await expect(bottomSheetDialog).toHaveCount(0)
+    await expect(bottomSheetOpener).toBeFocused()
+  })
+
+  test('should present an accessible bottom sheet on mobile', async ({ page }) => {
+    await page.setViewportSize({
+      height: 844,
+      width: 390
+    })
+
+    await page.locator('html').evaluate((element) => {
+      element.style.setProperty('--layout-safe-bottom', '24px')
+    })
+
+    const opener = page.getByRole('button', { name: 'Open bottom sheet' })
+
+    await opener.focus()
+    await page.keyboard.press('Enter')
+
+    const dialog = page.getByRole('dialog', { name: 'Bottom sheet' })
+    const filterInput = dialog.getByLabel('Filter name')
+    const closeButton = dialog.getByRole('button', { name: 'Close bottom sheet' })
+
+    await waitForDialogTransition(dialog)
+
+    const box = await expectBottomAnchored(dialog, page)
+    const viewport = getViewportSize(page)
+    const maximumHeight = viewport.height * 0.9 + 1
+
+    expect(box.inlineStart).toBeCloseTo(0)
+    expect(box.width).toBeCloseTo(viewport.width)
+    expect(box.height).toBeLessThanOrEqual(maximumHeight)
+
+    const styles = await dialog.evaluate((element) => {
+      const computedStyle = globalThis.getComputedStyle(element)
+
+      return {
+        overflowY: computedStyle.overflowY,
+        overscrollBehaviorY: computedStyle.overscrollBehaviorY,
+        paddingBlockEnd: computedStyle.paddingBlockEnd,
+        position: computedStyle.position,
+        scrollbarGutter: computedStyle.scrollbarGutter
+      }
+    })
+
+    expect(styles).toStrictEqual({
+      overflowY: 'auto',
+      overscrollBehaviorY: 'contain',
+      paddingBlockEnd: '24px',
+      position: 'fixed',
+      scrollbarGutter: 'stable'
+    })
+
+    await expect(filterInput).toBeFocused()
+    await page.keyboard.press('Tab')
+    await expect(closeButton).toBeFocused()
+    await page.keyboard.press('Tab')
+    await expect(opener).not.toBeFocused()
+    await page.keyboard.press('Tab')
+    await expect(filterInput).toBeFocused()
+
+    await page.mouse.click(viewport.width / 2, viewport.height - 2)
+    await expect(dialog).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(dialog).toHaveCount(0)
+    await expect(opener).toBeFocused()
+
+    await opener.click()
+    await waitForDialogTransition(dialog)
+    await page.mouse.click(1, 1)
+    await expect(dialog).toHaveCount(0)
+    await expect(opener).toBeFocused()
+  })
+
+  test('should block close requests while close is disabled', async ({ page }) => {
+    await page.setViewportSize({
+      height: 844,
+      width: 390
+    })
+
+    const opener = page.getByRole('button', { name: 'Open locked bottom sheet' })
+
+    await opener.focus()
+    await page.keyboard.press('Enter')
+
+    const dialog = page.getByRole('dialog', { name: 'Locked bottom sheet' })
+
+    await waitForDialogTransition(dialog)
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeVisible()
+
+    await page.mouse.click(1, 1)
+    await expect(dialog).toBeVisible()
+
+    await dialog.getByRole('button', { name: 'Complete locked bottom sheet' }).click()
+    await expect(dialog).toHaveCount(0)
+    await expect(opener).toBeFocused()
+  })
+
+  test('should keep long content reachable as the mobile viewport shrinks', async ({ page }) => {
+    await page.setViewportSize({
+      height: 844,
+      width: 390
+    })
+
+    const opener = page.getByRole('button', { name: 'Open long bottom sheet' })
+
+    await opener.click()
+
+    const dialog = page.getByRole('dialog', { name: 'Long bottom sheet' })
+
+    await waitForDialogTransition(dialog)
+
+    const initialBox = await expectBottomAnchored(dialog, page)
+
+    expect(initialBox.height).toBeLessThanOrEqual(844 * 0.9 + 1)
+
+    await page.setViewportSize({
+      height: 500,
+      width: 390
+    })
+
+    await expect.poll(async () => {
+      const box = await getElementBox(dialog)
+
+      return Math.round(box.blockStart + box.height)
+    }).toBe(500)
+
+    const compactBox = await expectBottomAnchored(dialog, page)
+
+    expect(compactBox.height).toBeLessThanOrEqual(500 * 0.9 + 1)
+
+    const closeButton = dialog.getByRole('button', { name: 'Close long bottom sheet' })
+
+    await closeButton.scrollIntoViewIfNeeded()
+    await expect(closeButton).toBeVisible()
+    await closeButton.click()
+    await expect(dialog).toHaveCount(0)
+    await expect(opener).toBeFocused()
+  })
+
+  test('should remove dialog motion when reduced motion is preferred', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.setViewportSize({
+      height: 844,
+      width: 390
+    })
+
+    await page.getByRole('button', { name: 'Open bottom sheet' }).click()
+
+    const dialog = page.getByRole('dialog', { name: 'Bottom sheet' })
+
+    await expect(dialog).toBeVisible()
+
+    const motionStyles = await dialog.evaluate((element) => {
+      const computedStyle = globalThis.getComputedStyle(element)
+      const transitionDurations = computedStyle.transitionDuration
+        .split(',')
+        .map((duration) => duration.trim())
+
+      return {
+        closedTranslate: computedStyle.getPropertyValue('--dialog-closed-translate').trim(),
+        transitionDurations
+      }
+    })
+
+    expect(motionStyles.closedTranslate).toBe('0')
+    expect(motionStyles.transitionDurations.every((duration) => duration === '0s')).toBe(true)
+  })
+})

--- a/tests/playwright/packing-lists/packing-list-shell.test.ts
+++ b/tests/playwright/packing-lists/packing-list-shell.test.ts
@@ -1,4 +1,4 @@
-import type { BrowserContext, Page, Request, Response, Route } from '@playwright/test'
+import type { BrowserContext, Locator, Page, Request, Response, Route } from '@playwright/test'
 import { expect, test } from '../fixtures/global.fixtures.ts'
 
 interface PackingListSummary {
@@ -419,6 +419,16 @@ async function openPackingLists(page: Page): Promise<void> {
   await sidebar.getByRole('link', { name: 'Packing lists' }).click()
 }
 
+async function getElementBox(locator: Locator) {
+  const box = await locator.boundingBox()
+
+  if (box === null) {
+    throw new Error('Expected element to have a bounding box')
+  }
+
+  return box
+}
+
 test.describe('Packing list shell', () => {
   test('should create a list and stay on the packing lists page', async ({ context, page }) => {
     const state = createPackingListRouteState([])
@@ -448,6 +458,47 @@ test.describe('Packing list shell', () => {
     await expect(page.getByRole('heading', { name: 'Create a packing list' })).toHaveCount(0)
     await expect(page.getByRole('link', { name: /Alpine weekend/iu })).toBeVisible()
     expect(state.detailRequests).toBe(0)
+  })
+
+  test('should keep the create dialog centered on mobile and restore focus', async ({ context, page }) => {
+    const state = createPackingListRouteState([])
+
+    await page.setViewportSize({
+      height: 844,
+      width: 390
+    })
+    await mockAuth(context)
+    await mockPackingListRoutes(context, page, state)
+    await page.goto('/login?redirectTo=/packing-lists')
+    await page.getByRole('button', { name: 'Guest' }).click()
+    await expect(page).toHaveURL(/\/packing-lists$/u)
+
+    const opener = page.getByRole('button', { name: 'New list' }).first()
+
+    await opener.focus()
+    await page.keyboard.press('Enter')
+
+    const dialog = page.getByRole('dialog', { name: 'Create a packing list' })
+
+    await expect(dialog).toBeVisible()
+
+    await expect.poll(
+      async () => dialog.evaluate((element) => globalThis.getComputedStyle(element).opacity)
+    ).toBe('1')
+
+    const box = await getElementBox(dialog)
+    const inlineCenter = box.x + box.width / 2
+    const blockCenter = box.y + box.height / 2
+    const inlineOffset = Math.abs(inlineCenter - 390 / 2)
+    const blockOffset = Math.abs(blockCenter - 844 / 2)
+
+    expect(box.width).toBeLessThan(390)
+    expect(inlineOffset).toBeLessThan(2)
+    expect(blockOffset).toBeLessThan(2)
+
+    await page.keyboard.press('Escape')
+    await expect(dialog).toHaveCount(0)
+    await expect(opener).toBeFocused()
   })
 
   test('should route from a list card to the item list page', async ({ context, page }) => {

--- a/tools/preview-e2e.sh
+++ b/tools/preview-e2e.sh
@@ -29,6 +29,7 @@ mkdir -p \
 
 NUXT_OAUTH_TWITCH_CLIENT_ID="${twitch_client_id}" \
 NUXT_OAUTH_TWITCH_CLIENT_SECRET="${twitch_client_secret}" \
+PERD_E2E_PAGES="true" \
   vp run build
 
 vp exec wrangler dev \


### PR DESCRIPTION
## Summary

Gives ModalDialog an opt-in mobile bottom-sheet mode without turning every dialog into a drawer 📱✨ Native dialog behavior stays in charge, while the responsive presentation gets the polish it needs 😎🤙

- 🎨 Add the bottom-sheet presentation at the mobile breakpoint while preserving centered dialogs by default
- 📐 Anchor sheets to the viewport bottom with safe-area spacing, bounded height, contained scrolling, and stable gutters
- ♿ Restore focus to the invoker and respect reduced-motion preferences
- 🛡️ Route Escape and Safari-compatible backdrop dismissal through cancelable close requests so close-disabled remains deterministic
- 🧪 Add focused browser coverage for desktop and mobile layouts, focus handling, dismissal rules, viewport resizing, and the packing-list filter flow
- 🔧 Register the dedicated dialog fixture only for E2E runs

## Motivation

Category filters need a native mobile sheet that stays usable around small viewports and the onscreen keyboard 📱💪 This keeps the component contract explicit and avoids changing confirmation or create dialogs that should remain centered.

## Related Issues

Fixes #202