### PR TITLE
Add equipment comparison read model

### DIFF
--- a/server/api/equipment/__tests__/comparisons.test.ts
+++ b/server/api/equipment/__tests__/comparisons.test.ts
@@ -1,0 +1,433 @@
+import * as h3 from 'h3'
+import type { SQL } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import comparisonsHandler from '#server/api/equipment/comparisons.get'
+import type { validateEquipmentComparisonQuery } from '#server/utils/validation/schemas'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+type EquipmentComparisonQuery = ReturnType<typeof validateEquipmentComparisonQuery>
+
+const firstItemId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+const secondItemId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d8'
+const thirdItemId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477d9'
+const fourthItemId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477da'
+
+const comparisonItemIds = [firstItemId, secondItemId, thirdItemId, fourthItemId]
+
+const { getValidatedQueryMock } = vi.hoisted(() => {
+  return {
+    getValidatedQueryMock: vi.fn<typeof h3.getValidatedQuery>()
+  }
+})
+
+// @ts-expect-error -- Vitest's import-based module mock typing rejects this partial h3 mock.
+vi.mock(import('h3'), async () => {
+  const actual = await vi.importActual<typeof h3>('h3')
+
+  return {
+    ...actual,
+
+    async getValidatedQuery(...args: Parameters<typeof h3.getValidatedQuery>) {
+      return getValidatedQueryMock(...args)
+    }
+  }
+})
+
+function createQuery(itemId: string[] = comparisonItemIds) : EquipmentComparisonQuery {
+  return { itemId }
+}
+
+function createItemRow(id: string, categoryId = 2) {
+  return {
+    id,
+    name: `Item ${id.at(-1)}`,
+    brand: {
+      name: `Brand ${id.at(-1)}`,
+      slug: `brand-${id.at(-1)}`
+    },
+    category: {
+      id: categoryId,
+      name: categoryId === 2 ? 'Stoves' : 'Cookware',
+      slug: categoryId === 2 ? 'stoves' : 'cookware'
+    }
+  }
+}
+
+function createComparisonDb({
+  definitions = [],
+  enumOptions = [],
+  items = [],
+  values = []
+}: {
+  definitions?: unknown[];
+  enumOptions?: unknown[];
+  items?: unknown[];
+  values?: unknown[];
+} = {}) {
+  const itemsWhereMock = vi.fn((_condition: SQL | undefined) => items)
+
+  const itemsCategoryJoinMock = vi.fn(() => {
+    return { where: itemsWhereMock }
+  })
+
+  const itemsBrandJoinMock = vi.fn(() => {
+    return { innerJoin: itemsCategoryJoinMock }
+  })
+
+  const itemsFromMock = vi.fn(() => {
+    return { innerJoin: itemsBrandJoinMock }
+  })
+
+  const definitionsOrderByMock = vi.fn((..._conditions: SQL[]) => definitions)
+
+  const definitionsWhereMock = vi.fn(() => {
+    return { orderBy: definitionsOrderByMock }
+  })
+
+  const definitionsFromMock = vi.fn(() => {
+    return { where: definitionsWhereMock }
+  })
+
+  const valuesWhereMock = vi.fn((_condition: SQL | undefined) => values)
+
+  const valuesInnerJoinMock = vi.fn(() => {
+    return { where: valuesWhereMock }
+  })
+
+  const valuesFromMock = vi.fn(() => {
+    return { innerJoin: valuesInnerJoinMock }
+  })
+
+  const enumOptionsWhereMock = vi.fn((_condition: SQL | undefined) => enumOptions)
+
+  const enumOptionsInnerJoinMock = vi.fn(() => {
+    return { where: enumOptionsWhereMock }
+  })
+
+  const enumOptionsFromMock = vi.fn(() => {
+    return { innerJoin: enumOptionsInnerJoinMock }
+  })
+
+  const selectMock = vi.fn((selection: Record<string, unknown>) => {
+    if ('brand' in selection) {
+      return { from: itemsFromMock }
+    }
+
+    if ('displayOrder' in selection) {
+      return { from: definitionsFromMock }
+    }
+
+    if ('valueBoolean' in selection) {
+      return { from: valuesFromMock }
+    }
+
+    return { from: enumOptionsFromMock }
+  })
+
+  return {
+    dbHttp: {
+      select: selectMock
+    },
+    definitionsOrderByMock,
+    enumOptionsWhereMock,
+    itemsWhereMock,
+    selectMock,
+    valuesWhereMock
+  }
+}
+
+function compileSql(value: SQL | undefined) {
+  if (value === undefined) {
+    throw new Error('Expected a defined SQL fragment')
+  }
+
+  const dialect = new PgDialect()
+
+  return dialect.sqlToQuery(value)
+}
+
+function compactSql(value: SQL | undefined) {
+  return compileSql(value).sql.replaceAll(/\s+/gu, ' ').trim()
+}
+
+describe('get /api/equipment/comparisons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getValidatedQueryMock.mockResolvedValue(createQuery())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each([2, 3, 4])('should return an ordered comparison for %i approved items', async (itemCount) => {
+    const itemIds = comparisonItemIds.slice(0, itemCount)
+    const itemRows = itemIds.map((itemId) => createItemRow(itemId)).toReversed()
+    const { dbHttp } = createComparisonDb({ items: itemRows })
+    const event = createTestEvent(dbHttp)
+
+    getValidatedQueryMock.mockResolvedValue(createQuery(itemIds))
+
+    const result = await comparisonsHandler(event)
+
+    expect(result.category).toStrictEqual({ id: 2, name: 'Stoves', slug: 'stoves' })
+    expect(result.items.map((item) => item.id)).toStrictEqual(itemIds)
+    expect(result.properties).toStrictEqual([])
+  })
+
+  it('should return every ordered typed value with enum display fallbacks', async () => {
+    const itemRows = [
+      createItemRow(thirdItemId),
+      createItemRow(firstItemId),
+      createItemRow(fourthItemId),
+      createItemRow(secondItemId)
+    ]
+
+    const definitions = [{
+      dataType: 'number',
+      displayOrder: 0,
+      id: 10,
+      name: 'Weight',
+      slug: 'weight',
+      unit: 'g'
+    }, {
+      dataType: 'text',
+      displayOrder: 1,
+      id: 11,
+      name: 'Notes',
+      slug: 'notes',
+      unit: null
+    }, {
+      dataType: 'boolean',
+      displayOrder: 2,
+      id: 12,
+      name: 'Piezo',
+      slug: 'piezo',
+      unit: null
+    }, {
+      dataType: 'enum',
+      displayOrder: 3,
+      id: 13,
+      name: 'Fuel',
+      slug: 'fuel',
+      unit: null
+    }]
+
+    const values = [{
+      itemId: firstItemId,
+      propertyId: 10,
+      valueBoolean: null,
+      valueNumber: '83.5',
+      valueText: null
+    }, {
+      itemId: thirdItemId,
+      propertyId: 10,
+      valueBoolean: null,
+      valueNumber: '100',
+      valueText: null
+    }, {
+      itemId: firstItemId,
+      propertyId: 11,
+      valueBoolean: null,
+      valueNumber: null,
+      valueText: 'three-season'
+    }, {
+      itemId: fourthItemId,
+      propertyId: 11,
+      valueBoolean: null,
+      valueNumber: null,
+      valueText: 'compact'
+    }, {
+      itemId: firstItemId,
+      propertyId: 12,
+      valueBoolean: true,
+      valueNumber: null,
+      valueText: null
+    }, {
+      itemId: secondItemId,
+      propertyId: 12,
+      valueBoolean: false,
+      valueNumber: null,
+      valueText: null
+    }, {
+      itemId: fourthItemId,
+      propertyId: 12,
+      valueBoolean: true,
+      valueNumber: null,
+      valueText: null
+    }, {
+      itemId: firstItemId,
+      propertyId: 13,
+      valueBoolean: null,
+      valueNumber: null,
+      valueText: 'canister'
+    }, {
+      itemId: secondItemId,
+      propertyId: 13,
+      valueBoolean: null,
+      valueNumber: null,
+      valueText: 'legacy-fuel'
+    }, {
+      itemId: thirdItemId,
+      propertyId: 13,
+      valueBoolean: null,
+      valueNumber: null,
+      valueText: 'alcohol'
+    }]
+
+    const enumOptions = [{ name: 'Canister', propertyId: 13, slug: 'canister' }, {
+      name: 'Alcohol',
+      propertyId: 13,
+      slug: 'alcohol'
+    }]
+
+    const {
+      dbHttp,
+      definitionsOrderByMock,
+      enumOptionsWhereMock,
+      itemsWhereMock,
+      selectMock,
+      valuesWhereMock
+    } = createComparisonDb({ definitions, enumOptions, items: itemRows, values })
+    const event = createTestEvent(dbHttp)
+    const result = await comparisonsHandler(event)
+
+    expect(result).toStrictEqual({
+      category: {
+        id: 2,
+        name: 'Stoves',
+        slug: 'stoves'
+      },
+
+      items: comparisonItemIds.map((itemId) => {
+        return {
+          id: itemId,
+          name: `Item ${itemId.at(-1)}`,
+          brand: {
+            name: `Brand ${itemId.at(-1)}`,
+            slug: `brand-${itemId.at(-1)}`
+          }
+        }
+      }),
+
+      properties: [{
+        dataType: 'number',
+        id: 10,
+        name: 'Weight',
+        slug: 'weight',
+        unit: 'g',
+        values: [
+          { itemId: firstItemId, value: 83.5 },
+          { itemId: secondItemId, value: null },
+          { itemId: thirdItemId, value: 100 },
+          { itemId: fourthItemId, value: null }
+        ]
+      }, {
+        dataType: 'text',
+        id: 11,
+        name: 'Notes',
+        slug: 'notes',
+        unit: null,
+        values: [
+          { itemId: firstItemId, value: 'three-season' },
+          { itemId: secondItemId, value: null },
+          { itemId: thirdItemId, value: null },
+          { itemId: fourthItemId, value: 'compact' }
+        ]
+      }, {
+        dataType: 'boolean',
+        id: 12,
+        name: 'Piezo',
+        slug: 'piezo',
+        unit: null,
+        values: [
+          { itemId: firstItemId, value: true },
+          { itemId: secondItemId, value: false },
+          { itemId: thirdItemId, value: null },
+          { itemId: fourthItemId, value: true }
+        ]
+      }, {
+        dataType: 'enum',
+        id: 13,
+        name: 'Fuel',
+        slug: 'fuel',
+        unit: null,
+        values: [{ enumOptionName: 'Canister', itemId: firstItemId, value: 'canister' }, {
+          itemId: secondItemId,
+          value: 'legacy-fuel'
+        }, {
+          enumOptionName: 'Alcohol',
+          itemId: thirdItemId,
+          value: 'alcohol'
+        }, {
+          itemId: fourthItemId,
+          value: null
+        }]
+      }]
+    })
+
+    expect(selectMock).toHaveBeenCalledTimes(4)
+    expect(valuesWhereMock).toHaveBeenCalledTimes(1)
+    expect(enumOptionsWhereMock).toHaveBeenCalledTimes(1)
+
+    const [itemWhereCall] = itemsWhereMock.mock.calls
+    const itemWhere = itemWhereCall?.[0]
+    const compiledItemWhere = compileSql(itemWhere)
+
+    expect(compiledItemWhere.sql).toContain('"equipment_items"."status" =')
+    expect(compiledItemWhere.params).toStrictEqual(['approved', ...comparisonItemIds])
+
+    const [orderByCall] = definitionsOrderByMock.mock.calls
+    const orderStatements = orderByCall?.map((condition) => compactSql(condition))
+
+    expect(orderStatements).toStrictEqual([
+      '"category_properties"."displayOrder" asc',
+      '"category_properties"."id" asc'
+    ])
+  })
+
+  it('should return 404 before enrichment when an approved item cannot be loaded', async () => {
+    const itemIds = [firstItemId, secondItemId]
+
+    const { dbHttp, selectMock } = createComparisonDb({
+      items: [createItemRow(firstItemId)]
+    })
+    const event = createTestEvent(dbHttp)
+
+    getValidatedQueryMock.mockResolvedValue(createQuery(itemIds))
+
+    await expect(comparisonsHandler(event)).rejects.toMatchObject({
+      statusCode: 404
+    })
+    expect(selectMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return 400 before enrichment for mixed categories', async () => {
+    const itemIds = [firstItemId, secondItemId]
+    const { dbHttp, selectMock } = createComparisonDb({
+      items: [createItemRow(firstItemId), createItemRow(secondItemId, 3)]
+    })
+    const event = createTestEvent(dbHttp)
+
+    getValidatedQueryMock.mockResolvedValue(createQuery(itemIds))
+
+    await expect(comparisonsHandler(event)).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(selectMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return 400 without querying the database when query validation fails', async () => {
+    const validationError = h3.createError({ status: 400 })
+    const { dbHttp, selectMock } = createComparisonDb()
+    const event = createTestEvent(dbHttp)
+
+    getValidatedQueryMock.mockRejectedValue(validationError)
+
+    await expect(comparisonsHandler(event)).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(selectMock).not.toHaveBeenCalled()
+  })
+})

--- a/server/api/equipment/comparisons.get.ts
+++ b/server/api/equipment/comparisons.get.ts
@@ -1,0 +1,305 @@
+import { and, asc, eq, inArray } from 'drizzle-orm'
+import { createError, defineEventHandler, getValidatedQuery } from 'h3'
+
+import {
+  brands,
+  categoryProperties,
+  equipmentCategories,
+  equipmentItems,
+  itemPropertyValues,
+  propertyEnumOptions
+} from '#server/database/schema'
+
+import {
+  getEquipmentPropertyDataType,
+  normalizeEquipmentPropertyValue,
+  type EquipmentPropertyDataType,
+  type EquipmentPropertyValue
+} from '#server/utils/equipment/property-values'
+
+import { validateEquipmentComparisonQuery } from '#server/utils/validation/schemas'
+
+interface ComparisonCategory {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface ComparisonItemBrand {
+  name: string;
+  slug: string;
+}
+
+interface ComparisonItemSummary {
+  brand: ComparisonItemBrand;
+  id: string;
+  name: string;
+}
+
+interface ComparisonPropertyValue {
+  enumOptionName?: string;
+  itemId: string;
+  value: EquipmentPropertyValue;
+}
+
+interface ComparisonProperty {
+  dataType: EquipmentPropertyDataType;
+  id: number;
+  name: string;
+  slug: string;
+  unit: string | null;
+  values: ComparisonPropertyValue[];
+}
+
+interface ComparisonResponse {
+  category: ComparisonCategory;
+  items: ComparisonItemSummary[];
+  properties: ComparisonProperty[];
+}
+
+interface PropertyValueRow {
+  itemId: string;
+  propertyId: number;
+  valueBoolean: boolean | null;
+  valueNumber: string | null;
+  valueText: string | null;
+}
+
+interface PropertyEnumOptionRow {
+  name: string;
+  propertyId: number;
+  slug: string;
+}
+
+/** Indexes stored EAV values by item and property ID. */
+function groupPropertyValues(rows: PropertyValueRow[]) {
+  const valuesByItemId = new Map<string, Map<number, PropertyValueRow>>()
+
+  for (const row of rows) {
+    const itemValues = valuesByItemId.get(row.itemId)
+
+    if (itemValues === undefined) {
+      valuesByItemId.set(row.itemId, new Map([[row.propertyId, row]]))
+    } else {
+      itemValues.set(row.propertyId, row)
+    }
+  }
+
+  return valuesByItemId
+}
+
+/** Indexes current enum option names by property ID and canonical slug. */
+function groupEnumOptionNames(rows: PropertyEnumOptionRow[]) {
+  const optionNamesByPropertyId = new Map<number, Map<string, string>>()
+
+  for (const row of rows) {
+    const optionNames = optionNamesByPropertyId.get(row.propertyId)
+
+    if (optionNames === undefined) {
+      optionNamesByPropertyId.set(row.propertyId, new Map([[row.slug, row.name]]))
+    } else {
+      optionNames.set(row.slug, row.name)
+    }
+  }
+
+  return optionNamesByPropertyId
+}
+
+export default defineEventHandler(async (event) : Promise<ComparisonResponse> => {
+  const { itemId: itemIds } = await getValidatedQuery(event, validateEquipmentComparisonQuery)
+  const { dbHttp } = event.context
+
+  const itemRows = await dbHttp
+    .select({
+      id: equipmentItems.id,
+      name: equipmentItems.name,
+
+      brand: {
+        name: brands.name,
+        slug: brands.slug
+      },
+
+      category: {
+        id: equipmentCategories.id,
+        name: equipmentCategories.name,
+        slug: equipmentCategories.slug
+      }
+    })
+    .from(equipmentItems)
+    .innerJoin(brands, eq(equipmentItems.brandId, brands.id))
+    .innerJoin(equipmentCategories, eq(equipmentItems.categoryId, equipmentCategories.id))
+    .where(
+      and(
+        eq(equipmentItems.status, 'approved'),
+        inArray(equipmentItems.id, itemIds)
+      )
+    )
+
+  if (itemRows.length !== itemIds.length) {
+    throw createError({ status: 404 })
+  }
+
+  const itemRowsById = new Map<string, (typeof itemRows)[number]>()
+
+  for (const itemRow of itemRows) {
+    itemRowsById.set(itemRow.id, itemRow)
+  }
+
+  const orderedItemRows: typeof itemRows = []
+
+  for (const itemId of itemIds) {
+    const itemRow = itemRowsById.get(itemId)
+
+    if (itemRow === undefined) {
+      throw createError({ status: 404 })
+    }
+
+    orderedItemRows.push(itemRow)
+  }
+
+  const [firstItem] = orderedItemRows
+
+  if (firstItem === undefined) {
+    throw createError({ status: 404 })
+  }
+
+  const categoryId = firstItem.category.id
+  let hasMixedCategories = false
+
+  for (const itemRow of orderedItemRows) {
+    if (itemRow.category.id !== categoryId) {
+      hasMixedCategories = true
+      break
+    }
+  }
+
+  if (hasMixedCategories) {
+    throw createError({
+      status: 400,
+      message: 'Items must belong to the same category'
+    })
+  }
+
+  const definitionsPromise = dbHttp
+    .select({
+      dataType: categoryProperties.dataType,
+      displayOrder: categoryProperties.displayOrder,
+      id: categoryProperties.id,
+      name: categoryProperties.name,
+      slug: categoryProperties.slug,
+      unit: categoryProperties.unit
+    })
+    .from(categoryProperties)
+    .where(
+      eq(categoryProperties.categoryId, categoryId)
+    )
+    .orderBy(
+      asc(categoryProperties.displayOrder),
+      asc(categoryProperties.id)
+    )
+
+  const valuesPromise = dbHttp
+    .select({
+      itemId: itemPropertyValues.itemId,
+      propertyId: itemPropertyValues.propertyId,
+      valueBoolean: itemPropertyValues.valueBoolean,
+      valueNumber: itemPropertyValues.valueNumber,
+      valueText: itemPropertyValues.valueText
+    })
+    .from(itemPropertyValues)
+    .innerJoin(categoryProperties, eq(itemPropertyValues.propertyId, categoryProperties.id))
+    .where(
+      and(
+        eq(categoryProperties.categoryId, categoryId),
+        inArray(itemPropertyValues.itemId, itemIds)
+      )
+    )
+
+  const enumOptionsPromise = dbHttp
+    .select({
+      name: propertyEnumOptions.name,
+      propertyId: propertyEnumOptions.propertyId,
+      slug: propertyEnumOptions.slug
+    })
+    .from(propertyEnumOptions)
+    .innerJoin(categoryProperties, eq(propertyEnumOptions.propertyId, categoryProperties.id))
+    .where(
+      eq(categoryProperties.categoryId, categoryId)
+    )
+
+  const [definitionRows, enumOptionRows, valueRows] = await Promise.all([
+    definitionsPromise,
+    enumOptionsPromise,
+    valuesPromise
+  ])
+
+  const valuesByItemId = groupPropertyValues(valueRows)
+  const enumOptionNamesByPropertyId = groupEnumOptionNames(enumOptionRows)
+  const items: ComparisonItemSummary[] = []
+
+  for (const itemRow of orderedItemRows) {
+    items.push({
+      brand: {
+        name: itemRow.brand.name,
+        slug: itemRow.brand.slug
+      },
+      id: itemRow.id,
+      name: itemRow.name
+    })
+  }
+
+  const properties: ComparisonProperty[] = []
+
+  for (const definition of definitionRows) {
+    const dataType = getEquipmentPropertyDataType(definition.dataType)
+    const values: ComparisonPropertyValue[] = []
+
+    for (const itemRow of orderedItemRows) {
+      const itemValues = valuesByItemId.get(itemRow.id)
+      const storedValue = itemValues?.get(definition.id)
+      const value = storedValue === undefined
+        ? null
+        : normalizeEquipmentPropertyValue({
+            dataType,
+            valueBoolean: storedValue.valueBoolean,
+            valueNumber: storedValue.valueNumber,
+            valueText: storedValue.valueText
+          })
+
+      const comparisonValue: ComparisonPropertyValue = {
+        itemId: itemRow.id,
+        value
+      }
+
+      if (dataType === 'enum' && typeof value === 'string') {
+        const optionNames = enumOptionNamesByPropertyId.get(definition.id)
+        const enumOptionName = optionNames?.get(value)
+
+        if (enumOptionName !== undefined) {
+          comparisonValue.enumOptionName = enumOptionName
+        }
+      }
+
+      values.push(comparisonValue)
+    }
+
+    properties.push({
+      dataType,
+      id: definition.id,
+      name: definition.name,
+      slug: definition.slug,
+      unit: definition.unit,
+      values
+    })
+  }
+
+  return {
+    category: {
+      id: firstItem.category.id,
+      name: firstItem.category.name,
+      slug: firstItem.category.slug
+    },
+    items,
+    properties
+  }
+})

--- a/server/utils/validation/__tests__/schemas.test.ts
+++ b/server/utils/validation/__tests__/schemas.test.ts
@@ -15,6 +15,7 @@ import {
   validateGroupIdParams,
   validateGroupMutationBody,
   validateItemDetailParams,
+  validateEquipmentComparisonQuery,
   validateItemsListQuery,
   validatePackingListAvailableGearQuery,
   validatePackingListEntryCreateBody,
@@ -761,6 +762,55 @@ describe('validation schemas', () => {
       search: 'pocket rocket',
       sort: 'property:weight'
     })
+  })
+
+  it('should preserve comparison item ID order from two to four values', () => {
+    const itemId = [
+      '0195f6e8-8f44-74f6-bc9a-5c8f7df477da',
+      '0195f6e8-8f44-74f6-bc9a-5c8f7df477d8',
+      '0195f6e8-8f44-74f6-bc9a-5c8f7df477d9',
+      '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+    ]
+    const result = validateEquipmentComparisonQuery({ itemId })
+
+    expect(result).toStrictEqual({ itemId })
+  })
+
+  it.each([
+    {},
+    { itemId: '' },
+    { itemId: [] },
+    { itemId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7' },
+    { itemId: ['0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'] },
+    {
+      itemId: [
+        '0195f6e8-8f44-44f6-bc9a-5c8f7df477d7',
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477d8'
+      ]
+    },
+    {
+      itemId: [
+        '0195F6E8-8F44-74F6-BC9A-5C8F7DF477D7',
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477d8'
+      ]
+    },
+    {
+      itemId: [
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+      ]
+    },
+    {
+      itemId: [
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477d8',
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477d9',
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477da',
+        '0195f6e8-8f44-74f6-bc9a-5c8f7df477db'
+      ]
+    }
+  ])('should reject invalid comparison query: %j', (query) => {
+    expect(() => validateEquipmentComparisonQuery(query)).toThrow(/./u)
   })
 
   it('should apply defaults for items list query', () => {

--- a/server/utils/validation/schemas.ts
+++ b/server/utils/validation/schemas.ts
@@ -201,6 +201,20 @@ const itemDetailParamsSchema = v.object({
   id: canonicalUuidV7Schema
 })
 
+const minimumEquipmentComparisonItemCount = 2
+const maximumEquipmentComparisonItemCount = 4
+
+const equipmentComparisonItemIdsQuerySchema = v.pipe(
+  v.array(canonicalUuidV7Schema),
+  v.minLength(minimumEquipmentComparisonItemCount),
+  v.maxLength(maximumEquipmentComparisonItemCount),
+  v.check((itemIds) => new Set(itemIds).size === itemIds.length, 'itemId must contain unique values')
+)
+
+const equipmentComparisonQuerySchema = v.object({
+  itemId: equipmentComparisonItemIdsQuerySchema
+})
+
 const userEquipmentIdParamsSchema = v.object({
   id: canonicalUuidV7Schema
 })
@@ -629,6 +643,10 @@ function validateItemDetailParams(params: unknown) {
   return v.parse(itemDetailParamsSchema, params)
 }
 
+function validateEquipmentComparisonQuery(query: unknown) {
+  return v.parse(equipmentComparisonQuerySchema, query)
+}
+
 function validateUserEquipmentIdParams(params: unknown) {
   return v.parse(userEquipmentIdParamsSchema, params)
 }
@@ -697,6 +715,7 @@ export {
   groupIdParamsSchema,
   groupMutationSchema,
   itemDetailParamsSchema,
+  equipmentComparisonQuerySchema,
   itemsListQuerySchema,
   limitQuerySchema,
   nonEmptyStringSchema,
@@ -730,6 +749,7 @@ export {
   validateGroupIdParams,
   validateGroupMutationBody,
   validateItemDetailParams,
+  validateEquipmentComparisonQuery,
   validateItemsListQuery,
   validatePackingListAvailableGearQuery,
   validatePackingListEntryCreateBody,


### PR DESCRIPTION
## Summary

Introduces a dedicated comparison read model so the gear library receives one deterministic property matrix without turning item detail into a shape-shifting endpoint 🧭😎

- 🚀 Add GET /api/equipment/comparisons with repeatable itemId values for two to four approved items
- 🧩 Preserve requested item order and emit every category property with an explicit value for every item, including null gaps
- 🏷️ Normalize number, text, boolean, and enum values while enriching current enum slugs with display names
- 🛡️ Reject malformed, duplicate, over-limit, and mixed-category requests before returning any partial matrix
- ✅ Cover validation, deterministic ordering, missing items, all property types, enum fallbacks, and failure responses

## Motivation

The original issue placed comparison under /api/equipment/items/compare and allowed one item for selection-tray restoration 🍻 After validating the requirements, comparison now lives as its own resource and requires two to four items 🧠✨ This keeps /api/equipment/items/:id focused on one catalog item, avoids ambiguous Nuxt route inference, and lets tray restoration continue through the existing detail endpoint.

## Related Issues

Fixes #683

Part of #677