### PR TITLE
feat(gear-library): build comparison flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,9 @@
 ## Verification
 
 - Run applicable checks in parallel where practical.
+- During development, run only focused checks for the code changed. Do not run full suites manually unless the user explicitly asks; commit hooks run the mandatory verification suite.
 - If you are creating a commit, do not run the mandatory verification suite manually first; commit hooks will run it.
-- You can pass only changed file paths to the test and lint commands during development, but verify that the full suite passes at the end of the change.
+- Pass changed file paths to test and lint commands when supported; otherwise use the narrowest applicable focused command.
 
 ## Local dev servers
 

--- a/app/components/gear-library/GearLibraryComparisonTable.vue
+++ b/app/components/gear-library/GearLibraryComparisonTable.vue
@@ -1,0 +1,292 @@
+<template>
+  <div
+    :class="$style.component"
+    :style="componentStyle"
+    :aria-label="scrollRegionLabel"
+    role="region"
+    tabindex="0"
+  >
+    <table :class="$style.table">
+      <caption :class="$style.visuallyHidden">
+        {{ caption }}
+      </caption>
+
+      <colgroup>
+        <col :class="$style.propertyColumn">
+
+        <col
+          v-for="item in items"
+          :key="item.id"
+        >
+      </colgroup>
+
+      <thead>
+        <tr>
+          <th :class="[$style.headerCell, $style.cornerCell]" scope="col">
+            <span :class="$style.visuallyHidden">Property</span>
+          </th>
+
+          <th
+            v-for="(item, itemIndex) in items"
+            :key="item.id"
+            :class="[$style.headerCell, $style.itemHeader]"
+            scope="col"
+          >
+            <div :class="$style.itemHeaderContent">
+              <span :class="$style.brand">{{ item.brand.name }}</span>
+
+              <button
+                ref="removeButtons"
+                type="button"
+                :class="$style.removeButton"
+                :aria-label="`Remove ${item.brand.name} ${item.name} from comparison`"
+                :data-item-id="item.id"
+                @click="handleRemove(item.id, itemIndex, $event)"
+              >
+                <Icon name="hugeicons:cancel-01" aria-hidden="true" />
+              </button>
+
+              <PerdLink
+                :class="$style.itemName"
+                :to="item.detailPath"
+                :aria-label="`View ${item.brand.name} ${item.name}`"
+              >
+                {{ item.name }}
+              </PerdLink>
+            </div>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr v-for="row in rows" :key="row.id">
+          <th :class="$style.propertyCell" scope="row">
+            {{ row.name }}
+          </th>
+
+          <td
+            v-for="value in row.values"
+            :key="value.itemId"
+            :class="$style.valueCell"
+          >
+            {{ value.displayValue }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script lang="ts">
+  import type { GearLibraryComparisonRow } from '~/utils/gear-library-comparison'
+
+  interface GearLibraryComparisonTableItemBrand {
+    name: string;
+  }
+
+  interface GearLibraryComparisonTableItem {
+    brand: GearLibraryComparisonTableItemBrand;
+    detailPath: string;
+    id: string;
+    name: string;
+  }
+
+  interface GearLibraryComparisonTableProps {
+    caption: string;
+    items: GearLibraryComparisonTableItem[];
+    rows: GearLibraryComparisonRow[];
+  }
+
+  export type {
+    GearLibraryComparisonTableItem,
+    GearLibraryComparisonTableItemBrand,
+    GearLibraryComparisonTableProps
+  }
+</script>
+
+<script lang="ts" setup>
+  import { computed, type CSSProperties, useTemplateRef } from 'vue'
+
+  import PerdLink from '~/components/PerdLink.vue'
+
+  interface Emits {
+    remove: [itemId: string, focusTargetId?: string];
+  }
+
+  const props = defineProps<GearLibraryComparisonTableProps>()
+  const emit = defineEmits<Emits>()
+  const removeButtons = useTemplateRef('removeButtons')
+
+  const scrollRegionLabel = computed(
+    () => `${props.caption}. Scroll horizontally to view all items.`
+  )
+
+  const componentStyle = computed<CSSProperties>(() => {
+    return {
+      '--comparison-item-count': props.items.length
+    }
+  })
+
+  function handleRemove(itemId: string, itemIndex: number, event: MouseEvent) {
+    const shouldRestoreFocus = event.detail === 0
+    const focusTarget = props.items[itemIndex + 1] ?? props.items[itemIndex - 1]
+    const focusTargetId = shouldRestoreFocus ? focusTarget?.id : undefined
+
+    emit('remove', itemId, focusTargetId)
+  }
+
+  function focusRemoveButton(itemId: string) {
+    const focusTarget = removeButtons.value?.find(
+      (button) => button.dataset.itemId === itemId
+    )
+
+    focusTarget?.focus()
+  }
+
+  defineExpose({ focusRemoveButton })
+</script>
+
+<style module>
+  .component {
+    --comparison-property-column-size: 9rem;
+    --comparison-item-column-min-size: 13rem;
+    --comparison-item-column-max-size: 20rem;
+
+    justify-self: start;
+    inline-size: min(
+      100%,
+      calc(
+        var(--comparison-property-column-size)
+        + (var(--comparison-item-count) * var(--comparison-item-column-max-size))
+      )
+    );
+    max-block-size: min(65dvb, 46rem);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--border-radius-16);
+    overflow: auto;
+    overscroll-behavior-inline: contain;
+    background-color: var(--color-background-elevated);
+    transition:
+      inline-size var(--transition-duration-normal) var(--transition-easing-standard);
+
+    &:focus-visible {
+      box-shadow: var(--shadow-focus);
+      outline: 2px solid var(--color-accent-primary);
+      outline-offset: 2px;
+    }
+  }
+
+  .table {
+    inline-size: 100%;
+    min-inline-size: calc(
+      var(--comparison-property-column-size)
+      + (var(--comparison-item-count) * var(--comparison-item-column-min-size))
+    );
+    border-collapse: separate;
+    border-spacing: 0;
+    table-layout: fixed;
+  }
+
+  .headerCell,
+  .propertyCell,
+  .valueCell {
+    padding: var(--spacing-12) var(--spacing-16);
+    border-block-end: 1px solid var(--color-border-subtle);
+    border-inline-end: 1px solid var(--color-border-subtle);
+    background-color: var(--color-background-elevated);
+    text-align: start;
+    vertical-align: top;
+  }
+
+  .propertyColumn {
+    inline-size: var(--comparison-property-column-size);
+  }
+
+  .headerCell {
+    position: sticky;
+    z-index: 2;
+    inset-block-start: 0;
+    min-inline-size: var(--comparison-item-column-min-size);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .cornerCell,
+  .propertyCell {
+    /* Keeps the sticky property rail stable while item columns share the remaining width. */
+    inline-size: var(--comparison-property-column-size);
+    min-inline-size: var(--comparison-property-column-size);
+    max-inline-size: var(--comparison-property-column-size);
+  }
+
+  .cornerCell {
+    z-index: 3;
+    inset-inline-start: 0;
+  }
+
+  .itemHeaderContent {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    column-gap: var(--spacing-8);
+    row-gap: var(--spacing-4);
+  }
+
+  .propertyCell {
+    position: sticky;
+    z-index: 1;
+    inset-inline-start: 0;
+    background-color: var(--color-surface-primary);
+    color: var(--color-text-primary);
+  }
+
+  .valueCell {
+    color: var(--color-text-secondary);
+  }
+
+  .brand {
+    display: block;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-12);
+    font-weight: var(--font-weight-regular);
+  }
+
+  .itemName {
+    grid-column: 1 / -1;
+    min-inline-size: 0;
+  }
+
+  .removeButton {
+    display: grid;
+    place-items: center;
+    inline-size: var(--layout-touch-target);
+    block-size: var(--layout-touch-target);
+    padding: 0;
+    border: 0;
+    border-radius: var(--border-radius-10);
+    background: transparent;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    font-size: var(--font-size-20);
+
+    &:hover {
+      background-color: var(--color-surface-tertiary);
+      color: var(--color-text-primary);
+    }
+
+    &:focus-visible {
+      box-shadow: var(--shadow-focus);
+    }
+  }
+
+  .visuallyHidden {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    padding: 0;
+    border: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+</style>

--- a/app/components/gear-library/GearLibraryComparisonTray.vue
+++ b/app/components/gear-library/GearLibraryComparisonTray.vue
@@ -43,6 +43,14 @@
 
           <div v-if="hasItems" :class="$style.actions">
             <PerdButton
+              :disabled="isCompareDisabled"
+              size="small"
+              @click="emit('compare')"
+            >
+              Compare
+            </PerdButton>
+
+            <PerdButton
               v-if="hasRestoreErrors"
               size="small"
               variant="secondary"
@@ -134,6 +142,7 @@
   }
 
   interface Emits {
+    compare: [];
     remove: [id: string, restoreFocus: boolean];
     retry: [];
   }
@@ -152,6 +161,7 @@
 
   const hasItems = computed(() => props.items.length > 0)
   const hasNoItems = computed(() => hasItems.value === false)
+  const isCompareDisabled = computed(() => props.items.length < 2)
   const selectedItemIds = computed(() => props.items.map((item) => item.id))
   const selectionCountText = computed(() => `${props.items.length} of 4 selected`)
 

--- a/app/pages/gear-library/compare.vue
+++ b/app/pages/gear-library/compare.vue
@@ -1,0 +1,494 @@
+<template>
+  <PageContent page-title="Compare gear">
+    <template #actions>
+      <PerdLink :to="backToCatalogLocation">
+        Edit compared items
+      </PerdLink>
+    </template>
+
+    <div :class="$style.component">
+      <PagePlaceholder
+        v-if="hasLocalValidationErrors"
+        emoji="🧭"
+        full-width
+        title="This comparison cannot be opened."
+      >
+        <ul :class="$style.errorList">
+          <li v-for="message in validationMessages" :key="message">
+            {{ message }}
+          </li>
+        </ul>
+      </PagePlaceholder>
+
+      <PageLoadingState
+        v-else-if="isComparisonPending"
+        title="Loading comparison"
+      />
+
+      <PagePlaceholder
+        v-else-if="hasComparisonError"
+        emoji="🧭"
+        full-width
+        title="Comparison unavailable."
+      >
+        {{ comparisonErrorMessage }}
+
+        <template v-if="canRetryComparison" #actions>
+          <PerdButton variant="secondary" @click="refreshComparison">
+            Retry
+          </PerdButton>
+        </template>
+      </PagePlaceholder>
+
+      <template v-else-if="comparisonResponse">
+        <header :class="$style.summary">
+          <div>
+            <PerdHeading :level="2">
+              {{ comparisonResponse.category.name }}
+            </PerdHeading>
+
+            <p :class="$style.count">
+              {{ comparisonCountText }}
+            </p>
+          </div>
+
+          <label :class="$style.differencesControl">
+            <input
+              v-model="showDifferencesOnly"
+              :class="$style.differencesCheckbox"
+              type="checkbox"
+            >
+            <span>Show differences only</span>
+          </label>
+        </header>
+
+        <section :class="$style.comparison" aria-label="Gear comparison">
+          <GearLibraryComparisonTable
+            ref="comparisonTable"
+            :caption="comparisonCaption"
+            :items="tableItems"
+            :rows="comparisonRows"
+            @remove="handleRemoveComparisonItem"
+          />
+
+          <p v-if="showEmptyState" :class="$style.emptyState" role="status">
+            {{ emptyStateMessage }}
+          </p>
+        </section>
+      </template>
+    </div>
+  </PageContent>
+</template>
+
+<script lang="ts" setup>
+  import {
+    computed,
+    nextTick,
+    ref,
+    useTemplateRef,
+    watch
+  } from 'vue'
+
+  import {
+    definePageMeta,
+    navigateTo,
+    useAsyncData,
+    useRequestFetch,
+    useRoute
+  } from '#imports'
+
+  import type { ComparisonResponse } from '#server/api/equipment/comparisons.get'
+
+  import {
+    createGearLibraryComparisonRows,
+    validateGearLibraryComparisonQuery
+  } from '~/utils/gear-library-comparison'
+
+  import { appRoutes, createGearLibraryItemPath } from '~/utils/navigation'
+
+  import GearLibraryComparisonTable, {
+    type GearLibraryComparisonTableItem
+  } from '~/components/gear-library/GearLibraryComparisonTable.vue'
+
+  import PageLoadingState from '~/components/PageLoadingState.vue'
+  import PagePlaceholder from '~/components/PagePlaceholder.vue'
+  import PerdButton from '~/components/PerdButton.vue'
+  import PerdHeading from '~/components/PerdHeading.vue'
+  import PerdLink from '~/components/PerdLink.vue'
+  import PageContent from '~/components/layout/PageContent.vue'
+
+  interface ErrorWithStatus {
+    status?: number;
+    statusCode?: number;
+  }
+
+  definePageMeta({
+    layout: 'page'
+  })
+
+  const route = useRoute()
+  const requestFetch = useRequestFetch()
+  const comparisonPath = '/api/equipment/comparisons' as const
+  const showDifferencesOnly = ref(false)
+  const pendingLocalComparisonSignature = ref<string>()
+  const pendingRemovalFocusItemId = ref<string>()
+  const comparisonTable = useTemplateRef('comparisonTable')
+
+  const comparisonValidation = computed(
+    () => validateGearLibraryComparisonQuery(route.query.item)
+  )
+  const orderedItemIds = computed(() => comparisonValidation.value.ids)
+
+  const comparisonRequest = await useAsyncData('gear-library-comparison', async (_nuxtApp, { signal }) => {
+    const validation = comparisonValidation.value
+
+    if (validation.isValid === false) {
+      return null
+    }
+
+    const query = {
+      itemId: validation.ids
+    }
+
+    const comparisonPromise = requestFetch(comparisonPath, {
+      query,
+      signal
+    })
+
+    return comparisonPromise
+  },
+  {
+    default: () => null
+  })
+
+  const {
+    clear: clearComparison,
+    data: comparisonResponse,
+    error: comparisonError,
+    refresh: refreshComparisonRequest,
+    status: comparisonStatus
+  } = comparisonRequest
+
+  const validationMessages = computed(() => {
+    const validation = comparisonValidation.value
+    const messages: string[] = []
+
+    if (validation.hasInsufficientIds) {
+      messages.push('Select 2 to 4 items to compare.')
+    }
+
+    if (validation.hasOverLimitIds) {
+      messages.push('This comparison contains more than 4 items.')
+    }
+
+    if (validation.hasInvalidIds) {
+      messages.push('This comparison link contains an invalid item ID.')
+    }
+
+    if (validation.hasDuplicateIds) {
+      messages.push('This comparison contains the same item more than once.')
+    }
+
+    return messages
+  })
+
+  const hasLocalValidationErrors = computed(() => validationMessages.value.length > 0)
+
+  const isComparisonPending = computed(
+    () => comparisonStatus.value === 'idle' || comparisonStatus.value === 'pending'
+  )
+
+  const hasComparisonError = computed(
+    () => comparisonError.value !== undefined && comparisonError.value !== null
+  )
+
+  function getErrorStatus(error: unknown) {
+    if (typeof error !== 'object' || error === null) {
+      return
+    }
+
+    const errorWithStatus = error as ErrorWithStatus
+
+    return errorWithStatus.statusCode ?? errorWithStatus.status
+  }
+
+  const comparisonErrorStatus = computed(() => getErrorStatus(comparisonError.value))
+
+  const comparisonErrorMessage = computed(() => {
+    if (comparisonErrorStatus.value === 400) {
+      return 'These items cannot be compared because they are not all from the same category.'
+    }
+
+    if (comparisonErrorStatus.value === 404) {
+      return 'One or more comparison items are unavailable.'
+    }
+
+    return 'Could not load this comparison.'
+  })
+
+  const canRetryComparison = computed(() => {
+    const status = comparisonErrorStatus.value
+
+    return status !== 400 && status !== 404
+  })
+
+  const comparisonCountText = computed(() => {
+    const itemCount = comparisonResponse.value?.items.length ?? 0
+
+    return `${itemCount} ${itemCount === 1 ? 'item' : 'items'}`
+  })
+
+  const comparisonCaption = computed(() => {
+    const categoryName = comparisonResponse.value?.category.name ?? ''
+
+    return `${categoryName}, ${comparisonCountText.value}`
+  })
+
+  function createTableItem(
+    item: ComparisonResponse['items'][number]
+  ): GearLibraryComparisonTableItem {
+    const itemId = item.id
+
+    return {
+      brand: {
+        name: item.brand.name
+      },
+      detailPath: createGearLibraryItemPath(itemId),
+      id: itemId,
+      name: item.name
+    }
+  }
+
+  const tableItems = computed(
+    () => comparisonResponse.value?.items.map(createTableItem) ?? []
+  )
+
+  const comparisonRows = computed(() => {
+    const response = comparisonResponse.value
+
+    if (response === null) {
+      return []
+    }
+
+    const visibleItemIds = response.items.map((item) => item.id)
+
+    return createGearLibraryComparisonRows(
+      response.properties,
+      visibleItemIds,
+      showDifferencesOnly.value
+    )
+  })
+
+  const hasNoComparisonProperties = computed(
+    () => comparisonResponse.value?.properties.length === 0
+  )
+
+  const showEmptyState = computed(
+    () => hasNoComparisonProperties.value || comparisonRows.value.length === 0
+  )
+
+  const emptyStateMessage = computed(() => {
+    if (hasNoComparisonProperties.value) {
+      return 'No comparison properties available.'
+    }
+
+    return 'No differences between these items.'
+  })
+
+  const backToCatalogLocation = computed(() => {
+    const response = comparisonResponse.value
+
+    if (response === null) {
+      return appRoutes.gearLibrary
+    }
+
+    return {
+      path: appRoutes.gearLibrary,
+      query: {
+        category: response.category.slug,
+        compare: orderedItemIds.value
+      }
+    }
+  })
+
+  async function refreshComparison() {
+    await refreshComparisonRequest()
+  }
+
+  function removeItemFromComparisonResponse(
+    response: ComparisonResponse,
+    itemId: string
+  ): ComparisonResponse {
+    const items = response.items.filter((item) => item.id !== itemId)
+    const properties = response.properties.map((property) => {
+      const values = property.values.filter((value) => value.itemId !== itemId)
+
+      return {
+        dataType: property.dataType,
+        id: property.id,
+        name: property.name,
+        slug: property.slug,
+        unit: property.unit,
+        values
+      }
+    })
+
+    return {
+      category: {
+        id: response.category.id,
+        name: response.category.name,
+        slug: response.category.slug
+      },
+      items,
+      properties
+    }
+  }
+
+  async function handleRemoveComparisonItem(
+    itemId: string,
+    focusTargetId?: string
+  ) {
+    const remainingItemIds = orderedItemIds.value.filter(
+      (selectedItemId) => selectedItemId !== itemId
+    )
+    const response = comparisonResponse.value
+
+    if (response === null) {
+      return
+    }
+
+    if (remainingItemIds.length < 2) {
+      const catalogLocation = {
+        path: appRoutes.gearLibrary,
+        query: {
+          category: response.category.slug,
+          compare: remainingItemIds
+        }
+      }
+
+      await navigateTo(catalogLocation, { replace: true })
+
+      return
+    }
+
+    const updatedResponse = removeItemFromComparisonResponse(response, itemId)
+    const remainingItemSignature = remainingItemIds.join(',')
+
+    comparisonResponse.value = updatedResponse
+    pendingLocalComparisonSignature.value = remainingItemSignature
+    pendingRemovalFocusItemId.value = focusTargetId
+
+    const comparisonLocation = {
+      path: route.path,
+      query: {
+        item: remainingItemIds
+      }
+    }
+
+    await navigateTo(comparisonLocation, { replace: true })
+
+    const currentItemSignature = comparisonValidation.value.ids.join(',')
+
+    if (currentItemSignature !== remainingItemSignature) {
+      comparisonResponse.value = response
+      pendingLocalComparisonSignature.value = undefined
+      pendingRemovalFocusItemId.value = undefined
+    }
+  }
+
+  watch(() => route.fullPath, async () => {
+    if (comparisonValidation.value.isValid === false) {
+      pendingRemovalFocusItemId.value = undefined
+      pendingLocalComparisonSignature.value = undefined
+
+      clearComparison()
+
+      return
+    }
+
+    const currentItemSignature = comparisonValidation.value.ids.join(',')
+
+    const isLocallyHandledRemoval = currentItemSignature
+      === pendingLocalComparisonSignature.value
+
+    pendingLocalComparisonSignature.value = undefined
+
+    if (isLocallyHandledRemoval === false) {
+      await refreshComparisonRequest()
+    }
+
+    const focusTargetId = pendingRemovalFocusItemId.value
+
+    if (focusTargetId === undefined) {
+      return
+    }
+
+    pendingRemovalFocusItemId.value = undefined
+
+    await nextTick()
+
+    comparisonTable.value?.focusRemoveButton(focusTargetId)
+  })
+</script>
+
+<style module>
+  .component {
+    display: grid;
+    gap: var(--spacing-24);
+  }
+
+  .summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-16);
+  }
+
+  .count {
+    color: var(--color-text-secondary);
+  }
+
+  .differencesControl {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-8);
+    min-block-size: var(--layout-touch-target);
+    color: var(--color-text-primary);
+    cursor: pointer;
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .differencesCheckbox {
+    inline-size: 1.15rem;
+    block-size: 1.15rem;
+    accent-color: var(--color-accent-primary);
+
+    &:focus-visible {
+      box-shadow: var(--shadow-focus);
+      outline: 2px solid var(--color-accent-primary);
+      outline-offset: 2px;
+    }
+  }
+
+  .comparison {
+    display: grid;
+    gap: var(--spacing-16);
+    min-inline-size: 0;
+  }
+
+  .emptyState {
+    padding: var(--spacing-24);
+    border: 1px dashed var(--color-border-strong);
+    border-radius: var(--border-radius-16);
+    background-color: var(--color-surface-primary);
+    color: var(--color-text-secondary);
+    text-align: center;
+  }
+
+  .errorList {
+    display: grid;
+    gap: var(--spacing-8);
+    text-align: start;
+  }
+</style>

--- a/app/pages/gear-library/index.vue
+++ b/app/pages/gear-library/index.vue
@@ -218,6 +218,7 @@
         :has-restore-errors="hasComparisonRestoreErrors"
         :items="selectedComparisonItems"
         :limit-announcement="comparisonLimitAnnouncement"
+        @compare="handleComparisonStart"
         @remove="handleComparisonTrayRemove"
         @retry="retryComparisonRestore"
       />
@@ -238,7 +239,7 @@
 <script lang="ts" setup>
   /* oxlint-disable max-lines -- The catalog page composes the existing data, filter, action, and restoration flows. */
   import { computed, nextTick, ref, useTemplateRef } from 'vue'
-  import { definePageMeta } from '#imports'
+  import { definePageMeta, navigateTo } from '#imports'
   import type { GearLibraryListItemView } from '~/types/equipment'
   import { useDelayedPendingIndicator } from '~/composables/use-delayed-pending-indicator'
   import { useGearLibraryControls } from '~/composables/use-gear-library-controls'
@@ -587,6 +588,17 @@
     await nextTick()
 
     comparisonModeAction.value?.focus()
+  }
+
+  async function handleComparisonStart() {
+    const comparisonQuery = {
+      item: selectedComparisonIds.value
+    }
+
+    await navigateTo({
+      path: '/gear-library/compare',
+      query: comparisonQuery
+    })
   }
 
   async function handleComparisonModeToggle() {

--- a/app/utils/__tests__/gear-library-comparison.test.ts
+++ b/app/utils/__tests__/gear-library-comparison.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ComparisonResponse } from '#server/api/equipment/comparisons.get'
+
+import {
+  areGearLibraryComparisonValuesEqual,
+  createGearLibraryComparisonRows,
+  formatGearLibraryComparisonValue,
+  validateGearLibraryComparisonQuery
+} from '~/utils/gear-library-comparison'
+
+const firstItemId = '01980000-0000-7000-8000-000000000001'
+const secondItemId = '01980000-0000-7000-8000-00000000000a'
+const thirdItemId = '01980000-0000-7000-8000-000000000003'
+const fourthItemId = '01980000-0000-7000-8000-000000000004'
+const fifthItemId = '01980000-0000-7000-8000-000000000005'
+
+const comparisonProperties: ComparisonResponse['properties'] = [
+  {
+    dataType: 'number',
+    id: 1,
+    name: 'Weight',
+    slug: 'weight',
+    unit: 'g',
+    values: [
+      { itemId: firstItemId, value: 500 },
+      { itemId: secondItemId, value: 500 },
+      { itemId: thirdItemId, value: null }
+    ]
+  },
+  {
+    dataType: 'enum',
+    id: 2,
+    name: 'Season',
+    slug: 'season',
+    unit: null,
+    values: [
+      { enumOptionName: 'Three season', itemId: firstItemId, value: 'three-season' },
+      { enumOptionName: 'Three season', itemId: secondItemId, value: 'three-season' },
+      { enumOptionName: 'Four season', itemId: thirdItemId, value: 'four-season' }
+    ]
+  }
+]
+
+describe(validateGearLibraryComparisonQuery, () => {
+  it.each([
+    [undefined, true, false],
+    [firstItemId, true, false],
+    [[firstItemId, secondItemId], false, true],
+    [[firstItemId, secondItemId, thirdItemId, fourthItemId], false, true],
+    [[firstItemId, secondItemId, thirdItemId, fourthItemId, fifthItemId], false, false]
+  ])('validates item count for %j', (value, hasInsufficientIds, isValid) => {
+    const result = validateGearLibraryComparisonQuery(value)
+
+    expect(result.hasInsufficientIds).toBe(hasInsufficientIds)
+    expect(result.isValid).toBe(isValid)
+  })
+
+  it('reports malformed, uppercase, null, duplicate, and over-limit values together', () => {
+    const result = validateGearLibraryComparisonQuery([
+      firstItemId,
+      firstItemId,
+      secondItemId.toUpperCase(),
+      null,
+      thirdItemId
+    ])
+
+    expect(result).toStrictEqual({
+      ids: [firstItemId, firstItemId, thirdItemId],
+      hasDuplicateIds: true,
+      hasInsufficientIds: false,
+      hasInvalidIds: true,
+      hasOverLimitIds: true,
+      isValid: false
+    })
+  })
+
+  it('preserves valid URL order', () => {
+    const result = validateGearLibraryComparisonQuery([thirdItemId, firstItemId, secondItemId])
+
+    expect(result.ids).toStrictEqual([thirdItemId, firstItemId, secondItemId])
+  })
+})
+
+describe('comparison values', () => {
+  it.each([
+    [[null, null], true],
+    [[null, 0], false],
+    [[true, true], true],
+    [[1, 1], true],
+    [['three-season', 'three-season'], true],
+    [['1', 1], false]
+  ])('compares raw values %j', (values, expected) => {
+    expect(areGearLibraryComparisonValuesEqual(values)).toBe(expected)
+  })
+
+  it('formats null, booleans, numbers, enums, and text', () => {
+    expect(formatGearLibraryComparisonValue(
+      { dataType: 'text', unit: null },
+      { itemId: firstItemId, value: null }
+    )).toBe('—')
+
+    expect(formatGearLibraryComparisonValue(
+      { dataType: 'boolean', unit: null },
+      { itemId: firstItemId, value: true }
+    )).toBe('Yes')
+
+    expect(formatGearLibraryComparisonValue(
+      { dataType: 'number', unit: 'g' },
+      { itemId: firstItemId, value: 500 }
+    )).toBe('500 g')
+
+    expect(formatGearLibraryComparisonValue(
+      { dataType: 'enum', unit: null },
+      { enumOptionName: 'Three season', itemId: firstItemId, value: 'three-season' }
+    )).toBe('Three season')
+
+    expect(formatGearLibraryComparisonValue(
+      { dataType: 'enum', unit: null },
+      { itemId: firstItemId, value: 'three-season' }
+    )).toBe('three-season')
+
+    expect(formatGearLibraryComparisonValue(
+      { dataType: 'text', unit: null },
+      { itemId: firstItemId, value: 'Dyneema' }
+    )).toBe('Dyneema')
+  })
+})
+
+describe(createGearLibraryComparisonRows, () => {
+  it('keeps category order and projects the requested selected items', () => {
+    const rows = createGearLibraryComparisonRows(
+      comparisonProperties,
+      [thirdItemId, firstItemId],
+      false
+    )
+
+    expect(rows.map((row) => row.slug)).toStrictEqual(['weight', 'season'])
+    expect(rows[0]?.values).toStrictEqual([
+      { displayValue: '—', itemId: thirdItemId, rawValue: null },
+      { displayValue: '500 g', itemId: firstItemId, rawValue: 500 }
+    ])
+  })
+
+  it('filters by all visible desktop columns', () => {
+    const rows = createGearLibraryComparisonRows(
+      comparisonProperties,
+      [firstItemId, secondItemId, thirdItemId],
+      true
+    )
+
+    expect(rows.map((row) => row.slug)).toStrictEqual(['weight', 'season'])
+  })
+
+  it('returns an empty state when every selected item has the same value', () => {
+    const rows = createGearLibraryComparisonRows(
+      comparisonProperties,
+      [firstItemId, secondItemId],
+      true
+    )
+
+    expect(rows).toStrictEqual([])
+  })
+})

--- a/app/utils/gear-library-comparison.ts
+++ b/app/utils/gear-library-comparison.ts
@@ -1,4 +1,30 @@
 import type { LocationQueryValue } from 'vue-router'
+import type { ComparisonResponse } from '#server/api/equipment/comparisons.get'
+
+type ComparisonProperty = ComparisonResponse['properties'][number]
+type ComparisonPropertyValue = ComparisonProperty['values'][number]
+
+interface GearLibraryComparisonValidation {
+  ids: string[];
+  hasDuplicateIds: boolean;
+  hasInsufficientIds: boolean;
+  hasInvalidIds: boolean;
+  hasOverLimitIds: boolean;
+  isValid: boolean;
+}
+
+interface GearLibraryComparisonDisplayValue {
+  displayValue: string;
+  itemId: string;
+  rawValue: ComparisonPropertyValue['value'];
+}
+
+interface GearLibraryComparisonRow {
+  id: number;
+  name: string;
+  slug: string;
+  values: GearLibraryComparisonDisplayValue[];
+}
 
 interface GearLibraryComparisonNormalization {
   ids: string[];
@@ -9,7 +35,142 @@ interface GearLibraryComparisonNormalization {
 }
 
 const maximumGearLibraryComparisonItems = 4
+const minimumGearLibraryComparisonItems = 2
 const canonicalUuidV7Pattern = /^[\da-f]{8}-[\da-f]{4}-7[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/u
+
+/** Validates a comparison-page query without correcting or dropping bad values. */
+function validateGearLibraryComparisonQuery(
+  value?: LocationQueryValue | LocationQueryValue[]
+): GearLibraryComparisonValidation {
+  const values: LocationQueryValue[] = []
+
+  if (Array.isArray(value)) {
+    values.push(...value)
+  } else if (value !== undefined) {
+    values.push(value)
+  }
+
+  const ids: string[] = []
+  const uniqueIds = new Set<string>()
+  let hasDuplicateIds = false
+  let hasInvalidIds = false
+
+  for (const queryValue of values) {
+    const isValidId = typeof queryValue === 'string'
+      && canonicalUuidV7Pattern.test(queryValue)
+
+    if (isValidId) {
+      ids.push(queryValue)
+
+      if (uniqueIds.has(queryValue)) {
+        hasDuplicateIds = true
+      } else {
+        uniqueIds.add(queryValue)
+      }
+    } else {
+      hasInvalidIds = true
+    }
+  }
+
+  const hasInsufficientIds = values.length < minimumGearLibraryComparisonItems
+  const hasOverLimitIds = values.length > maximumGearLibraryComparisonItems
+
+  const isValid = hasDuplicateIds === false
+    && hasInsufficientIds === false
+    && hasInvalidIds === false
+    && hasOverLimitIds === false
+
+  return {
+    ids,
+    hasDuplicateIds,
+    hasInsufficientIds,
+    hasInvalidIds,
+    hasOverLimitIds,
+    isValid
+  }
+}
+
+/** Compares stored typed values before any display formatting. */
+function areGearLibraryComparisonValuesEqual(
+  values: ComparisonPropertyValue['value'][]
+) {
+  const [firstValue, ...remainingValues] = values
+
+  return remainingValues.every((value) => value === firstValue)
+}
+
+/** Formats one typed comparison value for the matrix. */
+function formatGearLibraryComparisonValue(
+  property: Pick<ComparisonProperty, 'dataType' | 'unit'>,
+  propertyValue: ComparisonPropertyValue
+) {
+  const { value } = propertyValue
+
+  if (value === null) {
+    return '—'
+  }
+
+  if (property.dataType === 'boolean') {
+    return value === true ? 'Yes' : 'No'
+  }
+
+  if (property.dataType === 'enum' && typeof value === 'string') {
+    return propertyValue.enumOptionName ?? value
+  }
+
+  if (property.dataType === 'number' && property.unit !== null) {
+    return `${value} ${property.unit}`
+  }
+
+  return String(value)
+}
+
+/** Projects API properties into ordered rows for the currently visible item columns. */
+function createGearLibraryComparisonRows(
+  properties: ComparisonProperty[],
+  visibleItemIds: string[],
+  differencesOnly: boolean
+): GearLibraryComparisonRow[] {
+  const rows: GearLibraryComparisonRow[] = []
+
+  for (const property of properties) {
+    const valuesByItemId = new Map(
+      property.values.map((propertyValue) => [propertyValue.itemId, propertyValue])
+    )
+
+    const visibleValues: ComparisonPropertyValue[] = visibleItemIds.map(
+      (itemId) => valuesByItemId.get(itemId) ?? {
+        itemId,
+        value: null
+      }
+    )
+
+    const rawValues = visibleValues.map((propertyValue) => propertyValue.value)
+    const hasEqualValues = areGearLibraryComparisonValuesEqual(rawValues)
+    const shouldIncludeRow = differencesOnly === false || hasEqualValues === false
+
+    if (shouldIncludeRow) {
+      const values = visibleValues.map((propertyValue) => {
+        const displayValue = formatGearLibraryComparisonValue(property, propertyValue)
+
+        return {
+          displayValue,
+          itemId: propertyValue.itemId,
+          rawValue: propertyValue.value
+        }
+      })
+
+      rows.push({
+        id: property.id,
+        name: property.name,
+        slug: property.slug,
+        values
+      })
+    }
+  }
+
+  return rows
+}
 
 /** Normalizes ordered catalog comparison IDs and records every user-visible adjustment reason. */
 function normalizeGearLibraryComparisonQuery(
@@ -73,9 +234,19 @@ function normalizeGearLibraryComparisonQuery(
   }
 }
 
-export type { GearLibraryComparisonNormalization }
-
 export {
+  areGearLibraryComparisonValuesEqual,
+  createGearLibraryComparisonRows,
+  formatGearLibraryComparisonValue,
   maximumGearLibraryComparisonItems,
-  normalizeGearLibraryComparisonQuery
+  minimumGearLibraryComparisonItems,
+  normalizeGearLibraryComparisonQuery,
+  validateGearLibraryComparisonQuery
+}
+
+export type {
+  GearLibraryComparisonDisplayValue,
+  GearLibraryComparisonNormalization,
+  GearLibraryComparisonRow,
+  GearLibraryComparisonValidation
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
   webServer: {
     command: e2eWebServerCommand,
     url: appBaseUrl,
-    reuseExistingServer: false,
+    reuseExistingServer: isCI === false,
     timeout: 60_000,
 
     gracefulShutdown: {

--- a/server/api/equipment/comparisons.get.ts
+++ b/server/api/equipment/comparisons.get.ts
@@ -303,3 +303,7 @@ export default defineEventHandler(async (event) : Promise<ComparisonResponse> =>
     properties
   }
 })
+
+export type {
+  ComparisonResponse
+}

--- a/server/api/user/gear/index.get.ts
+++ b/server/api/user/gear/index.get.ts
@@ -108,3 +108,5 @@ export default defineEventHandler(async (event) : Promise<MyGearRecord[]> => {
       }
     })
 })
+
+export type { MyGearRecord }

--- a/tests/playwright/fixtures/gear-library-comparison.fixtures.ts
+++ b/tests/playwright/fixtures/gear-library-comparison.fixtures.ts
@@ -1,0 +1,232 @@
+import type { BrowserContext, Page, Request } from '@playwright/test'
+
+import type { ComparisonResponse } from '../../../server/api/equipment/comparisons.get'
+import { expect } from './global.fixtures.ts'
+
+interface ComparisonMockOptions {
+  comparison?: (request: Request) => {
+    json?: object;
+    status?: number;
+    waitFor?: Promise<void>;
+  };
+}
+
+interface ComparisonRequestTracker {
+  comparisons: Request[];
+}
+
+const comparisonItemIds = [
+  '01980000-0000-7000-8000-000000000001',
+  '01980000-0000-7000-8000-00000000000a',
+  '01980000-0000-7000-8000-000000000003',
+  '01980000-0000-7000-8000-000000000004'
+] as const
+
+const comparisonItems: ComparisonResponse['items'] = [
+  {
+    id: comparisonItemIds[0],
+    name: 'PocketRocket Deluxe',
+    brand: {
+      name: 'MSR',
+      slug: 'msr'
+    }
+  },
+  {
+    id: comparisonItemIds[1],
+    name: 'WindBurner',
+    brand: {
+      name: 'MSR',
+      slug: 'msr'
+    }
+  },
+  {
+    id: comparisonItemIds[2],
+    name: 'Lite Plus',
+    brand: {
+      name: 'Primus',
+      slug: 'primus'
+    }
+  },
+  {
+    id: comparisonItemIds[3],
+    name: 'Flash',
+    brand: {
+      name: 'Jetboil',
+      slug: 'jetboil'
+    }
+  }
+]
+
+const comparisonResponse: ComparisonResponse = {
+  category: {
+    id: 7,
+    name: 'Stoves',
+    slug: 'stoves'
+  },
+  items: comparisonItems,
+  properties: [
+    {
+      dataType: 'number',
+      id: 10,
+      name: 'Weight',
+      slug: 'weight',
+      unit: 'g',
+      values: [
+        { itemId: comparisonItemIds[0], value: 83 },
+        { itemId: comparisonItemIds[1], value: 83 },
+        { itemId: comparisonItemIds[2], value: null },
+        { itemId: comparisonItemIds[3], value: 371 }
+      ]
+    },
+    {
+      dataType: 'enum',
+      id: 11,
+      name: 'Fuel type',
+      slug: 'fuel-type',
+      unit: null,
+      values: comparisonItemIds.map((itemId) => {
+        return {
+          enumOptionName: 'Gas canister',
+          itemId,
+          value: 'gas-canister'
+        }
+      })
+    },
+    {
+      dataType: 'boolean',
+      id: 12,
+      name: 'Piezo ignition',
+      slug: 'piezo-ignition',
+      unit: null,
+      values: [
+        { itemId: comparisonItemIds[0], value: true },
+        { itemId: comparisonItemIds[1], value: false },
+        { itemId: comparisonItemIds[2], value: true },
+        { itemId: comparisonItemIds[3], value: true }
+      ]
+    }
+  ]
+}
+
+function createComparisonResponse(itemIds: readonly string[]): ComparisonResponse {
+  const itemsById = new Map(comparisonResponse.items.map((item) => [item.id, item]))
+  const items: ComparisonResponse['items'] = []
+
+  for (const itemId of itemIds) {
+    const item = itemsById.get(itemId)
+
+    if (item !== undefined) {
+      items.push(item)
+    }
+  }
+
+  const itemIdSet = new Set(itemIds)
+  const properties = comparisonResponse.properties.map((property) => {
+    const values = property.values.filter((value) => itemIdSet.has(value.itemId))
+
+    return {
+      dataType: property.dataType,
+      id: property.id,
+      name: property.name,
+      slug: property.slug,
+      unit: property.unit,
+      values
+    }
+  })
+
+  return {
+    category: comparisonResponse.category,
+    items,
+    properties
+  }
+}
+
+function getMockResponse(
+  resolver: ComparisonMockOptions[keyof ComparisonMockOptions],
+  request: Request,
+  fallback: object
+) {
+  return resolver?.(request) ?? {
+    json: fallback,
+    status: 200
+  }
+}
+
+async function fulfillMockResponse(
+  route: Parameters<Parameters<BrowserContext['route']>[1]>[0],
+  response: {
+    json?: object;
+    status?: number;
+    waitFor?: Promise<void>;
+  }
+) {
+  if (response.waitFor !== undefined) {
+    await response.waitFor
+  }
+
+  await route.fulfill({
+    json: response.json ?? {},
+    status: response.status ?? 200
+  })
+}
+
+async function mockComparisonApi(
+  context: BrowserContext,
+  options: ComparisonMockOptions = {}
+): Promise<ComparisonRequestTracker> {
+  const tracker: ComparisonRequestTracker = {
+    comparisons: []
+  }
+
+  await context.route((url) => url.pathname === '/api/equipment/comparisons', async (route) => {
+    const request = route.request()
+    tracker.comparisons.push(request)
+
+    const requestUrl = new globalThis.URL(request.url())
+    const itemIds = requestUrl.searchParams.getAll('itemId')
+    const defaultResponse = createComparisonResponse(itemIds)
+    const response = getMockResponse(options.comparison, request, defaultResponse)
+    await fulfillMockResponse(route, response)
+  })
+
+  return tracker
+}
+
+function createComparisonPath(itemIds: readonly string[]) {
+  const query = new globalThis.URLSearchParams()
+
+  for (const itemId of itemIds) {
+    query.append('item', itemId)
+  }
+
+  return `/gear-library/compare?${query.toString()}`
+}
+
+async function openComparisonPage(
+  page: Page,
+  itemIds: readonly string[] = comparisonItemIds.slice(0, 3)
+) {
+  const path = createComparisonPath(itemIds)
+  const redirectTo = encodeURIComponent(path)
+
+  await page.goto(`/login?redirectTo=${redirectTo}`)
+  await page.getByRole('button', { name: 'Guest' }).click()
+
+  await expect.poll(() => {
+    const currentUrl = new globalThis.URL(page.url())
+
+    return currentUrl.pathname
+  }).toBe('/gear-library/compare')
+}
+
+export {
+  comparisonItemIds,
+  comparisonItems,
+  comparisonResponse,
+  createComparisonResponse,
+  createComparisonPath,
+  mockComparisonApi,
+  openComparisonPage,
+  type ComparisonMockOptions,
+  type ComparisonRequestTracker
+}

--- a/tests/playwright/gear-library/gear-library-comparison.test.ts
+++ b/tests/playwright/gear-library/gear-library-comparison.test.ts
@@ -1,0 +1,741 @@
+import type { Locator, Request } from '@playwright/test'
+import { expect, test } from '../fixtures/global.fixtures.ts'
+import {
+  comparisonItemIds,
+  comparisonItems,
+  comparisonResponse,
+  createComparisonPath,
+  createComparisonResponse,
+  mockComparisonApi,
+  openComparisonPage
+} from '../fixtures/gear-library-comparison.fixtures.ts'
+import {
+  buildRouteSearch,
+  createDeferred,
+  getElementBox,
+  mockCatalogApi,
+  mockGuestLogin,
+  openGearLibrary,
+  scrollableItemsResponse
+} from '../fixtures/gear-library-entry-list.fixtures.ts'
+
+function getComparisonItemIds(request: Request) {
+  const requestUrl = new globalThis.URL(request.url())
+
+  return requestUrl.searchParams.getAll('itemId')
+}
+
+function getRequiredRequest(requests: Request[], index = 0) {
+  return requests[index]
+}
+
+function getRequiredCatalogItem(index: number) {
+  return scrollableItemsResponse.items[index]
+}
+
+async function getComparisonColumnWidths(table: Locator) {
+  const columnHeaders = await table.getByRole('columnheader').all()
+  const columnBoxes = await Promise.all(
+    columnHeaders.map(async (columnHeader) => getElementBox(columnHeader))
+  )
+
+  return columnBoxes.map((box) => box.width)
+}
+
+function expectComparisonColumnWidths(columnWidths: number[]) {
+  const propertyColumnWidth = columnWidths.at(0)
+  const itemColumnWidths = columnWidths.slice(1)
+  const firstItemColumnWidth = itemColumnWidths.at(0)
+
+  if (propertyColumnWidth === undefined || firstItemColumnWidth === undefined) {
+    throw new Error('Expected property and item comparison columns')
+  }
+
+  expect(propertyColumnWidth).toBeCloseTo(144, 0)
+  expect(firstItemColumnWidth).toBeGreaterThanOrEqual(208)
+  expect(firstItemColumnWidth).toBeLessThanOrEqual(320)
+
+  for (const itemColumnWidth of itemColumnWidths.slice(1)) {
+    expect(itemColumnWidth).toBeCloseTo(firstItemColumnWidth, 0)
+  }
+}
+
+function getFirstItemColumnWidth(columnWidths: number[]) {
+  const firstItemColumnWidth = columnWidths.at(1)
+
+  if (firstItemColumnWidth === undefined) {
+    throw new Error('Expected an item comparison column')
+  }
+
+  return firstItemColumnWidth
+}
+
+function createComparisonCatalogItemDetail(itemId?: string) {
+  const item = comparisonItems.find((comparisonItem) => comparisonItem.id === itemId)
+
+  if (item === undefined) {
+    return {
+      json: { statusCode: 404 },
+      status: 404
+    }
+  }
+
+  return {
+    json: {
+      brand: {
+        id: 1,
+        name: item.brand.name,
+        slug: item.brand.slug
+      },
+      category: {
+        id: comparisonResponse.category.id,
+        name: comparisonResponse.category.name,
+        slug: comparisonResponse.category.slug
+      },
+      createdAt: '2088-04-20T12:00:00.000Z',
+      id: item.id,
+      name: item.name,
+      properties: []
+    }
+  }
+}
+
+async function navigateWithinApp(page: Parameters<typeof openComparisonPage>[0], path: string) {
+  await page.evaluate(async (nextPath) => {
+    // oxlint-disable-next-line unicorn/consistent-function-scoping -- page.evaluate callbacks must be self-contained.
+    function getRequiredProperty(value: unknown, key: string): unknown {
+      const isObject = typeof value === 'object' && value !== null
+
+      if (isObject === false) {
+        throw new Error(`Expected an object containing ${key}`)
+      }
+
+      return Reflect.get(value, key)
+    }
+
+    const nuxtRoot = globalThis.document.querySelector('#__nuxt')
+    const vueApp: unknown = nuxtRoot === null
+      ? undefined
+      : Reflect.get(nuxtRoot, '__vue_app__')
+    const vueAppConfig = getRequiredProperty(vueApp, 'config')
+    const globalProperties = getRequiredProperty(vueAppConfig, 'globalProperties')
+    const router = getRequiredProperty(globalProperties, '$router')
+    const push = getRequiredProperty(router, 'push')
+
+    if (typeof push !== 'function') {
+      throw new TypeError('Expected the Nuxt router push function')
+    }
+
+    await Reflect.apply(push, router, [nextPath])
+  }, path)
+}
+
+function createGatedComparisonResponder(
+  gatedItemIds: readonly string[],
+  waitFor: Promise<void>
+) {
+  return (request: Request) => {
+    const itemIds = getComparisonItemIds(request)
+    const response = {
+      json: createComparisonResponse(itemIds)
+    }
+
+    if (itemIds.join(',') === gatedItemIds.join(',')) {
+      return {
+        ...response,
+        waitFor
+      }
+    }
+
+    return response
+  }
+}
+
+const directItemCounts = [2, 3, 4] as const
+const invalidComparisonCases = [
+  {
+    itemIds: [comparisonItemIds[0]],
+    message: 'Select 2 to 4 items to compare.',
+    name: 'insufficient'
+  },
+  {
+    itemIds: [comparisonItemIds[0], comparisonItemIds[0]],
+    message: 'This comparison contains the same item more than once.',
+    name: 'duplicate'
+  },
+  {
+    itemIds: [...comparisonItemIds, '01980000-0000-7000-8000-000000000005'],
+    message: 'This comparison contains more than 4 items.',
+    name: 'over limit'
+  },
+  {
+    itemIds: [comparisonItemIds[0], comparisonItemIds[1].toUpperCase()],
+    message: 'This comparison link contains an invalid item ID.',
+    name: 'malformed'
+  }
+] as const
+const comparisonErrorCases = [
+  {
+    message: 'These items cannot be compared because they are not all from the same category.',
+    status: 400
+  },
+  {
+    message: 'One or more comparison items are unavailable.',
+    status: 404
+  }
+] as const
+
+test.describe('Gear library comparison page', () => {
+  test.beforeEach(async ({ context }) => {
+    await mockGuestLogin(context)
+  })
+
+  test('should start from the tray in URL and column order and preserve catalog history', async ({
+    context,
+    page
+  }) => {
+    await mockCatalogApi(context, {
+      items: () => {
+        return { json: scrollableItemsResponse }
+      }
+    })
+
+    const selectedItems = [
+      getRequiredCatalogItem(0),
+      getRequiredCatalogItem(1)
+    ]
+    const selectedIds = selectedItems.map((item) => item.id)
+    const selectedResponse = {
+      ...comparisonResponse,
+      items: selectedItems.map((item) => {
+        return {
+          brand: item.brand,
+          id: item.id,
+          name: item.name
+        }
+      }),
+      properties: comparisonResponse.properties.map((property) => {
+        return {
+          ...property,
+          values: selectedIds.map((itemId, index) => {
+            return {
+              itemId,
+              value: index
+            }
+          })
+        }
+      })
+    }
+
+    const tracker = await mockComparisonApi(context, {
+      comparison: () => {
+        return { json: selectedResponse }
+      }
+    })
+
+    const catalogSearch = buildRouteSearch([
+      ['q', 'rocket'],
+      ['category', 'stoves']
+    ])
+
+    await openGearLibrary(page, `/gear-library${catalogSearch}`)
+    await page.getByRole('button', { name: 'Compare items' }).click()
+
+    const compareButton = page.getByRole('button', { name: 'Compare', exact: true })
+
+    await page.getByRole('checkbox', { name: `Select ${selectedItems[0]?.name}` }).check()
+    await expect(compareButton).toBeDisabled()
+
+    await page.getByRole('checkbox', { name: `Select ${selectedItems[1]?.name}` }).check()
+    await expect(compareButton).toBeEnabled()
+    await compareButton.click()
+
+    await expect(page).toHaveURL(createComparisonPath(selectedIds))
+    await expect.poll(() => tracker.comparisons.length).toBe(1)
+    const comparisonRequest = getRequiredRequest(tracker.comparisons)
+
+    expect(getComparisonItemIds(comparisonRequest)).toStrictEqual(selectedIds)
+
+    const columnHeaders = page.getByRole('columnheader')
+
+    await expect(columnHeaders.nth(1)).toContainText(selectedItems[0].name)
+    await expect(columnHeaders.nth(2)).toContainText(selectedItems[1].name)
+
+    await page.goBack()
+    const selectedCatalogSearch = buildRouteSearch([
+      ['q', 'rocket'],
+      ['category', 'stoves'],
+      ...selectedIds.map((itemId) => ['compare', itemId] as const)
+    ])
+
+    await expect(page).toHaveURL(`/gear-library${selectedCatalogSearch}`)
+    await expect(page.getByText('2 of 4 selected')).toBeVisible()
+  })
+
+  for (const itemCount of directItemCounts) {
+    test(`should render a direct URL with ${itemCount} ordered items`, async ({
+      context,
+      page
+    }) => {
+      const tracker = await mockComparisonApi(context)
+      const itemIds = comparisonItemIds.slice(0, itemCount)
+
+      await openComparisonPage(page, itemIds)
+
+      const table = page.getByRole('table', {
+        name: `Stoves, ${itemCount} items`
+      })
+
+      await expect(table).toBeVisible()
+      await expect(table.getByRole('columnheader')).toHaveCount(itemCount + 1)
+      await expect(table.getByRole('rowheader')).toHaveCount(comparisonResponse.properties.length)
+
+      const comparisonRequest = getRequiredRequest(tracker.comparisons)
+      expect(getComparisonItemIds(comparisonRequest)).toStrictEqual(itemIds)
+
+      const catalogLink = page.getByRole('link', { name: 'Edit compared items' })
+      const expectedCatalogSearch = new globalThis.URLSearchParams()
+      expectedCatalogSearch.append('category', 'stoves')
+
+      for (const itemId of itemIds) {
+        expectedCatalogSearch.append('compare', itemId)
+      }
+
+      await expect(catalogLink).toHaveAttribute(
+        'href',
+        `/gear-library?${expectedCatalogSearch.toString()}`
+      )
+    })
+  }
+
+  for (const invalidCase of invalidComparisonCases) {
+    test(`should reject a locally ${invalidCase.name} URL without calling the API`, async ({
+      context,
+      page
+    }) => {
+      const tracker = await mockComparisonApi(context)
+
+      await openComparisonPage(page, invalidCase.itemIds)
+
+      await expect(page.getByText(invalidCase.message, { exact: true })).toBeVisible()
+      expect(tracker.comparisons).toHaveLength(0)
+      await expect(page.getByRole('link', { name: 'Edit compared items' })).toHaveAttribute(
+        'href',
+        '/gear-library'
+      )
+    })
+  }
+
+  for (const errorCase of comparisonErrorCases) {
+    test(`should map a ${errorCase.status} response to a non-retryable state`, async ({
+      context,
+      page
+    }) => {
+      await mockComparisonApi(context, {
+        comparison: () => {
+          return { status: errorCase.status }
+        }
+      })
+
+      await openComparisonPage(page)
+
+      await expect(page.getByText(errorCase.message, { exact: true })).toBeVisible()
+      await expect(page.getByRole('button', { name: 'Retry' })).toHaveCount(0)
+    })
+  }
+
+  test('should retry a server failure and render the complete matrix', async ({
+    context,
+    page
+  }) => {
+    const responseState: {
+      response: {
+        json?: object;
+        status?: number;
+      };
+    } = {
+      response: { status: 500 }
+    }
+
+    await mockComparisonApi(context, {
+      comparison: () => responseState.response
+    })
+
+    await openComparisonPage(page)
+
+    await expect(page.getByText('Could not load this comparison.', { exact: true })).toBeVisible()
+    responseState.response = {
+      json: createComparisonResponse(comparisonItemIds.slice(0, 3))
+    }
+    await page.getByRole('button', { name: 'Retry' }).click()
+
+    await expect(page.getByRole('table', { name: 'Stoves, 3 items' })).toBeVisible()
+  })
+
+  test('should abort a stale comparison request when item parameters change', async ({
+    context,
+    page
+  }) => {
+    const staleRequestGate = createDeferred()
+    const staleItemIds = [
+      comparisonItemIds[0],
+      comparisonItemIds[1],
+      comparisonItemIds[3]
+    ]
+    const finalItemIds = [
+      comparisonItemIds[1],
+      comparisonItemIds[2],
+      comparisonItemIds[3]
+    ]
+
+    await mockComparisonApi(context, {
+      comparison: createGatedComparisonResponder(staleItemIds, staleRequestGate.promise)
+    })
+
+    await openComparisonPage(page)
+    await expect(page.getByRole('table', { name: 'Stoves, 3 items' })).toBeVisible()
+
+    const staleRequestStarted = page.waitForRequest((request) => (
+      getComparisonItemIds(request).join(',') === staleItemIds.join(',')
+    ))
+    const staleRequestFailure = page.waitForEvent('requestfailed', (request) => (
+      new globalThis.URL(request.url()).searchParams.getAll('itemId').join(',')
+        === staleItemIds.join(',')
+    ))
+
+    await navigateWithinApp(page, createComparisonPath(staleItemIds))
+    await staleRequestStarted
+    await navigateWithinApp(page, createComparisonPath(finalItemIds))
+
+    const failedRequest = await staleRequestFailure
+
+    expect(failedRequest.failure()?.errorText).toContain('ERR_ABORTED')
+    staleRequestGate.resolve()
+
+    await expect(page).toHaveURL(createComparisonPath(finalItemIds))
+    await expect(page.getByRole('table', { name: 'Stoves, 3 items' })).toBeVisible()
+    await expect(page.getByRole('columnheader').nth(1)).toContainText(comparisonItems[1].name)
+  })
+
+  test('should filter desktop rows by all visible raw values', async ({
+    context,
+    page
+  }) => {
+    await mockComparisonApi(context)
+    await openComparisonPage(page)
+
+    const table = page.getByRole('table', { name: 'Stoves, 3 items' })
+
+    await expect(table.getByRole('rowheader')).toHaveText([
+      'Weight',
+      'Fuel type',
+      'Piezo ignition'
+    ])
+
+    await page.getByRole('checkbox', { name: 'Show differences only' }).check()
+
+    await expect(table.getByRole('rowheader')).toHaveText([
+      'Weight',
+      'Piezo ignition'
+    ])
+    await expect(table.getByText('—', { exact: true })).toBeVisible()
+
+    const propertyHeaderPosition = await table.getByRole('rowheader').first().evaluate(
+      (element) => globalThis.getComputedStyle(element).position
+    )
+    const itemHeaderPosition = await table.getByRole('columnheader').nth(1).evaluate(
+      (element) => globalThis.getComputedStyle(element).position
+    )
+
+    expect(propertyHeaderPosition).toBe('sticky')
+    expect(itemHeaderPosition).toBe('sticky')
+  })
+
+  test('should show every selected item on mobile with accessible hidden table labels', async ({
+    context,
+    page
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    const pageRequests: Request[] = []
+
+    page.on('request', (request) => {
+      pageRequests.push(request)
+    })
+
+    await mockComparisonApi(context)
+    await openComparisonPage(page, comparisonItemIds)
+
+    const table = page.getByRole('table', { name: 'Stoves, 4 items' })
+    const columnHeaders = table.getByRole('columnheader')
+    const cornerHeader = columnHeaders.first()
+    const caption = table.locator('caption')
+
+    await expect(table).toBeVisible()
+    await expect(columnHeaders).toHaveCount(5)
+    await expect(columnHeaders.nth(1)).toContainText('MSR')
+    await expect(columnHeaders.nth(1)).toContainText(comparisonItems[0].name)
+    await expect(cornerHeader).toHaveAccessibleName('Property')
+    await expect(caption).toHaveText('Stoves, 4 items')
+
+    const propertyLabel = cornerHeader.getByText('Property', { exact: true })
+    const [captionBox, propertyLabelBox] = await Promise.all([
+      getElementBox(caption),
+      getElementBox(propertyLabel)
+    ])
+    const [captionClipPath, propertyLabelClipPath] = await Promise.all([
+      caption.evaluate((element) => globalThis.getComputedStyle(element).clipPath),
+      propertyLabel.evaluate((element) => globalThis.getComputedStyle(element).clipPath)
+    ])
+
+    expect(captionBox.width).toBe(1)
+    expect(captionBox.height).toBe(1)
+    expect(propertyLabelBox.width).toBe(1)
+    expect(propertyLabelBox.height).toBe(1)
+    expect(captionClipPath).toBe('inset(50%)')
+    expect(propertyLabelClipPath).toBe('inset(50%)')
+    await expect(page.getByRole('combobox')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: /my gear/iu })).toHaveCount(0)
+    await expect(table.getByRole('rowheader')).toHaveText([
+      'Weight',
+      'Fuel type',
+      'Piezo ignition'
+    ])
+
+    await page.getByRole('checkbox', { name: 'Show differences only' }).check()
+
+    await expect(table.getByRole('rowheader')).toHaveText([
+      'Weight',
+      'Piezo ignition'
+    ])
+    const membershipRequests = pageRequests.filter((request) => {
+      const requestUrl = new globalThis.URL(request.url())
+
+      return requestUrl.pathname.startsWith('/api/user/gear')
+    })
+
+    expect(membershipRequests).toHaveLength(0)
+  })
+
+  test('should keep the full mobile matrix horizontally scrollable and page wheel usable', async ({
+    context,
+    page
+  }) => {
+    await page.setViewportSize({ width: 390, height: 500 })
+    const longItemName = 'Enlightened Equipment Enigma 20F Regular'
+    const shortItemName = 'Seed Sleeping Bag 03'
+    const response = createComparisonResponse(comparisonItemIds)
+    response.items = [
+      {
+        ...comparisonItems[0],
+        name: longItemName
+      },
+      {
+        ...comparisonItems[1],
+        name: shortItemName
+      },
+      comparisonItems[2],
+      comparisonItems[3]
+    ]
+
+    await mockComparisonApi(context, {
+      comparison: () => {
+        return { json: response }
+      }
+    })
+    await openComparisonPage(page, comparisonItemIds)
+
+    const table = page.getByRole('table', { name: 'Stoves, 4 items' })
+    const scrollRegion = page.getByRole('region', {
+      name: 'Stoves, 4 items. Scroll horizontally to view all items.'
+    })
+    const longItemRemoveButton = page.getByRole('button', {
+      name: `Remove MSR ${longItemName} from comparison`
+    })
+    const longItemLink = page.getByRole('link', {
+      name: `View MSR ${longItemName}`
+    })
+    const shortItemRemoveButton = page.getByRole('button', {
+      name: `Remove MSR ${shortItemName} from comparison`
+    })
+    const [
+      longItemLinkBox,
+      longItemRemoveButtonBox,
+      scrollRegionBox,
+      shortItemRemoveButtonBox
+    ] = await Promise.all([
+      getElementBox(longItemLink),
+      getElementBox(longItemRemoveButton),
+      getElementBox(scrollRegion),
+      getElementBox(shortItemRemoveButton)
+    ])
+    const scrollGeometry = await scrollRegion.evaluate((element) => {
+      return {
+        borderBoxWidth: element.getBoundingClientRect().width,
+        clientWidth: element.clientWidth,
+        scrollbarGutter: globalThis.getComputedStyle(element).scrollbarGutter,
+        scrollWidth: element.scrollWidth
+      }
+    })
+    const columnWidths = await getComparisonColumnWidths(table)
+    const longItemLinkInlineEnd = longItemLinkBox.x + longItemLinkBox.width
+
+    expectComparisonColumnWidths(columnWidths)
+    expect(longItemRemoveButtonBox.y).toBeCloseTo(shortItemRemoveButtonBox.y, 0)
+    expect(longItemLinkInlineEnd).toBeGreaterThan(longItemRemoveButtonBox.x)
+    expect(scrollGeometry.scrollWidth).toBeGreaterThan(scrollGeometry.clientWidth)
+    expect(scrollGeometry.borderBoxWidth - scrollGeometry.clientWidth).toBe(2)
+    expect(scrollGeometry.scrollbarGutter).toBe('auto')
+
+    await scrollRegion.evaluate((element) => {
+      element.scrollLeft = element.scrollWidth
+    })
+    await expect.poll(
+      async () => scrollRegion.evaluate((element) => element.scrollLeft)
+    ).toBeGreaterThan(0)
+
+    const lastColumnHeader = table.getByRole('columnheader').last()
+    const lastColumnHeaderBox = await getElementBox(lastColumnHeader)
+    const scrollRegionInlineEnd = scrollRegionBox.x + scrollRegionBox.width
+    const lastColumnHeaderInlineEnd = lastColumnHeaderBox.x + lastColumnHeaderBox.width
+
+    expect(lastColumnHeaderBox.x).toBeLessThan(scrollRegionInlineEnd)
+    expect(lastColumnHeaderInlineEnd).toBeGreaterThan(scrollRegionBox.x)
+
+    await page.evaluate(() => {
+      globalThis.scrollTo(0, 0)
+    })
+    const scrollRegionPointerX = scrollRegionBox.x + (scrollRegionBox.width / 2)
+    const scrollRegionPointerY = scrollRegionBox.y + (scrollRegionBox.height / 2)
+
+    await page.mouse.move(scrollRegionPointerX, scrollRegionPointerY)
+    const pageScrollBeforeWheel = await page.evaluate(() => globalThis.scrollY)
+
+    expect(pageScrollBeforeWheel).toBe(0)
+
+    await page.mouse.wheel(0, 300)
+
+    await expect.poll(
+      async () => page.evaluate(() => globalThis.scrollY)
+    ).toBeGreaterThan(pageScrollBeforeWheel)
+  })
+
+  test('should keep columns stable while removing locally and restoring keyboard focus', async ({
+    context,
+    page
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    const tracker = await mockComparisonApi(context)
+    await openComparisonPage(page, comparisonItemIds)
+
+    const fourItemTable = page.getByRole('table', { name: 'Stoves, 4 items' })
+    const fourItemRegion = fourItemTable.locator('..')
+    const firstPropertyRowHeader = fourItemTable.getByRole('rowheader').first()
+    const fourItemRegionBox = await getElementBox(fourItemRegion)
+    const fourItemColumnWidths = await getComparisonColumnWidths(fourItemTable)
+    const firstPropertyRowBox = await getElementBox(firstPropertyRowHeader)
+    const reducedMotionDuration = await fourItemRegion.evaluate(
+      (element) => globalThis.getComputedStyle(element).transitionDuration
+    )
+
+    expectComparisonColumnWidths(fourItemColumnWidths)
+    expect(firstPropertyRowBox.width).toBeCloseTo(144, 0)
+    expect(reducedMotionDuration).toBe('0s')
+
+    const differencesCheckbox = page.getByRole('checkbox', {
+      name: 'Show differences only'
+    })
+    await differencesCheckbox.check()
+
+    const firstRemoveButton = page.getByRole('button', {
+      name: `Remove MSR ${comparisonItems[0].name} from comparison`
+    })
+    await firstRemoveButton.focus()
+    await firstRemoveButton.press('Enter')
+
+    const threeItemIds = comparisonItemIds.slice(1)
+    await expect(page).toHaveURL(createComparisonPath(threeItemIds))
+    const threeItemTable = page.getByRole('table', { name: 'Stoves, 3 items' })
+
+    await expect(threeItemTable).toBeVisible()
+    const threeItemRegionBox = await getElementBox(threeItemTable.locator('..'))
+    const threeItemColumnWidths = await getComparisonColumnWidths(threeItemTable)
+
+    await expect(page.getByText('Loading comparison', { exact: true })).toHaveCount(0)
+    await expect(differencesCheckbox).toBeChecked()
+    expectComparisonColumnWidths(threeItemColumnWidths)
+    expect(threeItemRegionBox.x).toBeCloseTo(fourItemRegionBox.x, 0)
+    expect(tracker.comparisons).toHaveLength(1)
+
+    const secondRemoveButton = page.getByRole('button', {
+      name: `Remove MSR ${comparisonItems[1].name} from comparison`
+    })
+    await expect(secondRemoveButton).toBeFocused()
+
+    const expectedCatalogSearch = buildRouteSearch([
+      ['category', 'stoves'],
+      ...threeItemIds.map((itemId) => ['compare', itemId] as const)
+    ])
+    await expect(page.getByRole('link', { name: 'Edit compared items' })).toHaveAttribute(
+      'href',
+      `/gear-library${expectedCatalogSearch}`
+    )
+
+    await secondRemoveButton.press('Enter')
+
+    const twoItemIds = comparisonItemIds.slice(2)
+    await expect(page).toHaveURL(createComparisonPath(twoItemIds))
+    const twoItemTable = page.getByRole('table', { name: 'Stoves, 2 items' })
+
+    await expect(twoItemTable).toBeVisible()
+    const twoItemRegionBox = await getElementBox(twoItemTable.locator('..'))
+    const twoItemColumnWidths = await getComparisonColumnWidths(twoItemTable)
+    const twoItemColumnWidth = getFirstItemColumnWidth(twoItemColumnWidths)
+    const threeItemColumnWidth = getFirstItemColumnWidth(threeItemColumnWidths)
+
+    await expect(page.getByText('Loading comparison', { exact: true })).toHaveCount(0)
+    await expect(differencesCheckbox).toBeChecked()
+    expectComparisonColumnWidths(twoItemColumnWidths)
+    expect(twoItemRegionBox.x).toBeCloseTo(fourItemRegionBox.x, 0)
+    expect(twoItemColumnWidth).toBeCloseTo(threeItemColumnWidth, 0)
+    expect(tracker.comparisons).toHaveLength(1)
+    await expect(page.getByRole('button', {
+      name: `Remove Primus ${comparisonItems[2].name} from comparison`
+    })).toBeFocused()
+  })
+
+  test('should return to the category with one selected item after removing from a pair', async ({
+    context,
+    page
+  }) => {
+    await mockCatalogApi(context, {
+      itemDetails: (request) => {
+        const itemId = request.url.pathname.split('/').at(-1)
+
+        return createComparisonCatalogItemDetail(itemId)
+      }
+    })
+    await mockComparisonApi(context)
+    const pairItemIds = comparisonItemIds.slice(0, 2)
+
+    await openComparisonPage(page, pairItemIds)
+    await page.getByRole('button', {
+      name: `Remove MSR ${comparisonItems[0].name} from comparison`
+    }).click()
+
+    const catalogSearch = buildRouteSearch([
+      ['category', 'stoves'],
+      ['compare', comparisonItemIds[1]]
+    ])
+
+    await expect(page).toHaveURL(`/gear-library${catalogSearch}`)
+    await expect(page.getByText('1 of 4 selected', { exact: true })).toBeVisible()
+    await expect(page.getByRole('button', {
+      name: 'Compare',
+      exact: true
+    })).toBeDisabled()
+    await expect(page.getByRole('button', {
+      name: `Remove ${comparisonItems[1].name} from comparison`
+    })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

Turns the catalog selection tray into a complete, shareable comparison flow 🧭📊 The same semantic matrix now works across viewport sizes, with horizontal scrolling keeping all selected items available on mobile 😎🤙

- ✨ Launch comparisons from the catalog tray with 2–4 ordered `item` query parameters
- 🧭 Validate shared URLs locally and handle loading, retryable server failures, and stale-request cancellation
- 📊 Render an accessible sticky comparison matrix in category property order across desktop and mobile
- 🔎 Filter rows by raw typed-value differences, including nulls, booleans, numbers, enums, and text
- ⌨️ Remove columns locally, keep the URL and catalog return state synchronized, and restore keyboard focus
- ✅ Cover query validation, value projection, tray navigation, direct URLs, responsive scrolling, error states, request cancellation, and item removal

## Motivation

Issue #685 had the ordered catalog selection flow but no dedicated destination for comparing selected equipment. This change completes that path using the existing ordered comparison API while keeping the full 2–4 item matrix available at every viewport size 🎯

The implemented responsive behavior intentionally uses one horizontally scrollable semantic table instead of separate mobile pair selectors. My Gear mutations are not part of this PR. This keeps the comparison interaction consistent and focused on the confirmed catalog-to-comparison flow 📱🖥️

## Related issues

Closes #685