### PR TITLE
feat(equipment): add gear submissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,11 @@
 
 - Import `test` and `expect` from `tests/playwright/fixtures/global.fixtures.ts`, not from `@playwright/test`.
 - When a flow should cancel stale requests, assert the obsolete request fails with `requestfailed`; final UI state alone is insufficient.
+
+## Local database
+
+- During local development, agents may use `psql` with `NUXT_DATABASE_URL` to inspect actual database state whenever it helps diagnose, implement, or verify the current task, even when the task did not begin as database work.
+- Before changing data directly, verify that `NUXT_LOCAL_DATABASE` is enabled. Local development data is disposable: agents may insert, update, or delete it without additional approval when doing so supports the current task.
+- This permission applies only to the local database. Never infer the same permission for staging or production.
+- Never print database URLs, credentials, or secret values.
+- Report material data mutations and what was removed or changed.

--- a/app/components/NumberInput.vue
+++ b/app/components/NumberInput.vue
@@ -1,0 +1,122 @@
+<template>
+  <div :class="$style.component">
+    <label :for="inputId" :class="$style.label">
+      {{ label }}
+    </label>
+
+    <input
+      :id="inputId"
+      v-model="value"
+      :class="$style.input"
+      :disabled="disabled"
+      :name="name"
+      :aria-describedby="describedBy"
+      type="number"
+      inputmode="decimal"
+      step="any"
+    >
+
+    <span v-if="hasUnit" :id="unitId" :class="$style.hint">
+      Unit: {{ unit }}
+    </span>
+
+    <span
+      v-if="hasError"
+      :id="errorId"
+      :class="$style.errorMessage"
+      role="alert"
+    >
+      {{ error }}
+    </span>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { computed, useId } from 'vue'
+
+  interface Props {
+    disabled?: boolean;
+    error?: string;
+    label: string;
+    name: string;
+    unit?: string | null;
+  }
+
+  const {
+    disabled,
+    error,
+    label,
+    name,
+    unit
+  } = defineProps<Props>()
+
+  const value = defineModel<string>({
+    required: true
+  })
+
+  const componentId = useId()
+  const inputId = `${componentId}-input`
+  const unitId = `${componentId}-unit`
+  const errorId = `${componentId}-error`
+  const hasUnit = computed(() => unit !== undefined && unit !== null)
+  const hasError = computed(() => error !== undefined)
+
+  const describedBy = computed(() => {
+    const ids = []
+
+    if (hasUnit.value) {
+      ids.push(unitId)
+    }
+
+    if (hasError.value) {
+      ids.push(errorId)
+    }
+
+    return ids.length === 0 ? undefined : ids.join(' ')
+  })
+</script>
+
+<style module>
+  .component {
+    display: grid;
+    align-content: start;
+    gap: var(--spacing-8);
+  }
+
+  .label {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-14);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .input {
+    inline-size: 100%;
+    min-block-size: var(--layout-button-height-medium);
+    padding-inline: var(--spacing-12);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--layout-button-radius-small);
+    background-color: var(--color-background-elevated);
+    color: var(--color-text-primary);
+    font: inherit;
+
+    &:hover:not(:disabled) {
+      border-color: var(--color-accent-primary);
+    }
+
+    &:focus-visible {
+      border-color: var(--color-accent-primary);
+      outline: 2px solid var(--color-accent-primary);
+      outline-offset: 2px;
+      box-shadow: var(--shadow-focus);
+    }
+  }
+
+  .hint {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-14);
+  }
+
+  .errorMessage {
+    color: var(--color-danger-primary);
+  }
+</style>

--- a/app/components/PerdButton.vue
+++ b/app/components/PerdButton.vue
@@ -1,9 +1,14 @@
 <template>
-  <button
+  <component
+    :is="rootComponent"
     ref="buttonRef"
-    :type="type"
-    :disabled="isButtonDisabled"
+    :type="buttonType"
+    :to="linkTarget"
+    :role="linkRole"
+    :disabled="buttonDisabled"
+    :aria-disabled="linkAriaDisabled"
     :aria-busy="ariaBusy"
+    :tabindex="linkTabIndex"
     :class="[$style.component, {
       small: isSmallSize,
       large: isLargeSize,
@@ -13,6 +18,7 @@
       danger: isDangerVariant,
       block
     }]"
+    @click.capture="handleClick"
   >
     <FidgetSpinner
       v-if="loading"
@@ -32,11 +38,13 @@
       :name="rightIconName"
       :class="$style.icon"
     />
-  </button>
+  </component>
 </template>
 
 <script lang="ts" setup>
-  import { computed, useTemplateRef } from 'vue'
+  import { computed, useTemplateRef, type ComponentPublicInstance } from 'vue'
+  import type { RouteLocationRaw } from 'vue-router'
+  import { NuxtLink } from '#components'
   import FidgetSpinner from '~/components/FidgetSpinner.vue'
 
   interface Props {
@@ -46,9 +54,12 @@
     iconRight?: string;
     loading?: boolean;
     size?: 'large' | 'medium' | 'small';
+    to?: RouteLocationRaw;
     type?: 'button' | 'reset' | 'submit';
     variant?: 'danger' | 'ghost' | 'primary' | 'secondary' | 'soft';
   }
+
+  type ButtonRoot = ComponentPublicInstance | HTMLElement
 
   const {
     block = false,
@@ -56,13 +67,31 @@
     iconRight,
     loading = false,
     size = 'medium',
+    to,
     type = 'button',
     variant = 'primary'
   } = defineProps<Props>()
-  const buttonRef = useTemplateRef('buttonRef')
 
-  const ariaBusy = computed(() => loading || undefined)
+  const buttonRef = useTemplateRef<ButtonRoot>('buttonRef')
+  const isLink = computed(() => to !== undefined)
   const isButtonDisabled = computed(() => disabled || loading)
+  const isLinkDisabled = computed(() => isLink.value && isButtonDisabled.value)
+
+  const rootComponent = computed(() => {
+    if (isLinkDisabled.value) {
+      return 'span'
+    }
+
+    return isLink.value ? NuxtLink : 'button'
+  })
+
+  const buttonType = computed(() => isLink.value ? undefined : type)
+  const buttonDisabled = computed(() => isLink.value ? undefined : isButtonDisabled.value)
+  const linkTarget = computed(() => isLinkDisabled.value ? undefined : to)
+  const linkRole = computed(() => isLinkDisabled.value ? 'link' : undefined)
+  const linkAriaDisabled = computed(() => isLinkDisabled.value || undefined)
+  const linkTabIndex = computed(() => isLinkDisabled.value ? -1 : undefined)
+  const ariaBusy = computed(() => loading || undefined)
   const isSmallSize = computed(() => size === 'small')
   const isLargeSize = computed(() => size === 'large')
   const isSecondaryVariant = computed(() => variant === 'secondary')
@@ -72,8 +101,18 @@
   const rightIconName = computed(() => iconRight ?? '')
   const showRightIcon = computed(() => iconRight !== undefined && iconRight !== '' && loading === false)
 
+  function handleClick(event: MouseEvent) {
+    if (isLinkDisabled.value) {
+      event.preventDefault()
+      event.stopImmediatePropagation()
+    }
+  }
+
   function focus() {
-    buttonRef.value?.focus()
+    const root = buttonRef.value
+    const rootElement = root instanceof globalThis.HTMLElement ? root : root?.$el
+
+    rootElement?.focus()
   }
 
   defineExpose({ focus })
@@ -109,13 +148,14 @@
     font-weight: var(--font-weight-semibold);
     font-size: var(--font-size-16);
     line-height: var(--line-height-snug);
+    text-decoration: none;
     transition:
       background-color var(--transition-duration-normal) var(--transition-easing-standard),
       border-color var(--transition-duration-normal) var(--transition-easing-standard),
       box-shadow var(--transition-duration-normal) var(--transition-easing-standard),
       color var(--transition-duration-normal) var(--transition-easing-standard);
 
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled, [aria-disabled='true']) {
       border-color: var(--button-border-color-hover);
       background-color: var(--button-background-hover);
     }
@@ -126,7 +166,7 @@
       box-shadow: var(--shadow-focus), var(--button-shadow);
     }
 
-    &:active:not(:disabled) {
+    &:active:not(:disabled, [aria-disabled='true']) {
       border-color: var(--button-border-color-hover);
       background-color: var(--button-background-active);
     }
@@ -150,8 +190,8 @@
 
     &:global(.secondary) {
       --button-background: color-mix(in oklch, var(--color-background-elevated) 88%, var(--color-accent-subtle));
-      --button-background-hover: var(--color-surface-secondary);
-      --button-background-active: var(--color-background-muted);
+      --button-background-hover: var(--color-accent-subtle-hover);
+      --button-background-active: var(--color-accent-subtle-active);
       --button-border-color: var(--color-border-strong);
       --button-border-color-hover: color-mix(in oklch, var(--color-accent-primary) 34%, transparent);
       --button-shadow: inset 0 1px 0 color-mix(in oklch, var(--color-white) 44%, transparent);
@@ -194,7 +234,8 @@
       }
     }
 
-    &:disabled {
+    &:disabled,
+    &[aria-disabled='true'] {
       cursor: not-allowed;
       background-color: var(--color-surface-secondary);
       border-color: var(--color-border-subtle);

--- a/app/components/TextInput.vue
+++ b/app/components/TextInput.vue
@@ -1,0 +1,92 @@
+<template>
+  <div :class="$style.component">
+    <label :for="inputId" :class="$style.label">
+      {{ label }}
+    </label>
+
+    <input
+      :id="inputId"
+      ref="input"
+      v-model="value"
+      :class="$style.input"
+      :disabled="disabled"
+      :maxlength="maxlength"
+      :name="name"
+      :placeholder="placeholder"
+      :required="required"
+      type="text"
+      autocomplete="off"
+    >
+  </div>
+</template>
+
+<script lang="ts" setup>
+  import { useId, useTemplateRef } from 'vue'
+
+  interface Props {
+    disabled?: boolean;
+    label: string;
+    maxlength?: number;
+    name: string;
+    placeholder?: string;
+    required?: boolean;
+  }
+
+  const {
+    disabled,
+    label,
+    maxlength,
+    name,
+    placeholder,
+    required
+  } = defineProps<Props>()
+
+  const value = defineModel<string>({
+    required: true
+  })
+
+  const inputId = useId()
+  const input = useTemplateRef('input')
+
+  function focus() {
+    input.value?.focus()
+  }
+
+  defineExpose({ focus })
+</script>
+
+<style module>
+  .component {
+    display: grid;
+    align-content: start;
+    gap: var(--spacing-8);
+  }
+
+  .label {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-14);
+    font-weight: var(--font-weight-semibold);
+  }
+
+  .input {
+    inline-size: 100%;
+    min-block-size: var(--layout-button-height-medium);
+    padding-inline: var(--spacing-12);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--layout-button-radius-small);
+    background-color: var(--color-background-elevated);
+    color: var(--color-text-primary);
+    font: inherit;
+
+    &:hover:not(:disabled) {
+      border-color: var(--color-accent-primary);
+    }
+
+    &:focus-visible {
+      border-color: var(--color-accent-primary);
+      outline: 2px solid var(--color-accent-primary);
+      outline-offset: 2px;
+      box-shadow: var(--shadow-focus);
+    }
+  }
+</style>

--- a/app/components/gear-library/GearLibraryComparisonTray.vue
+++ b/app/components/gear-library/GearLibraryComparisonTray.vue
@@ -2,7 +2,7 @@
   <div :class="$style.component" :style="componentStyle">
     <aside
       :class="$style.tray"
-      aria-labelledby="gear-library-comparison-heading"
+      :aria-labelledby="headingId"
       data-testid="gear-library-comparison-tray"
     >
       <div ref="surface" :class="$style.surface">
@@ -28,7 +28,7 @@
 
         <header :class="$style.header">
           <div>
-            <PerdHeading id="gear-library-comparison-heading" :level="2">
+            <PerdHeading :id="headingId" :level="2">
               Compare items
             </PerdHeading>
 
@@ -149,6 +149,7 @@
 
   const props = defineProps<Props>()
   const emit = defineEmits<Emits>()
+  const headingId = useId()
   const isItemListExpanded = ref(false)
   const pendingFocusTarget = ref<string>()
   const itemListId = useId()

--- a/app/components/gear-library/GearLibraryFilters.vue
+++ b/app/components/gear-library/GearLibraryFilters.vue
@@ -15,6 +15,7 @@
 
           <PerdButton
             ref="filterTrigger"
+            size="small"
             variant="secondary"
             aria-haspopup="dialog"
             :aria-expanded="isDialogOpen"

--- a/app/components/gear-library/GearLibraryItemRow.vue
+++ b/app/components/gear-library/GearLibraryItemRow.vue
@@ -88,7 +88,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
+  import { computed, useId } from 'vue'
 
   import type {
     GearLibraryListItemView,
@@ -120,7 +120,7 @@
   const weightPropertySlug = 'weight'
   const props = defineProps<Props>()
   const emit = defineEmits<Emits>()
-  const comparisonControlId = computed(() => `compare-${props.item.id}`)
+  const comparisonControlId = useId()
 
   function handleComparisonChange(event: Event) {
     const checkbox = event.currentTarget

--- a/app/components/packing-lists/PackingListCreateDialog.vue
+++ b/app/components/packing-lists/PackingListCreateDialog.vue
@@ -2,7 +2,7 @@
   <ModalDialog
     v-model="isOpened"
     :close-disabled="loading"
-    aria-labelledby="new-packing-list-dialog-title"
+    :aria-labelledby="headingId"
   >
     <form :class="$style.component" @submit.prevent="handleSubmit">
       <div :class="$style.header">
@@ -12,7 +12,7 @@
           </div>
 
           <PerdHeading
-            id="new-packing-list-dialog-title"
+            :id="headingId"
             :class="$style.heading"
             :level="2"
           >
@@ -32,7 +32,7 @@
       </div>
 
       <div :class="$style.field">
-        <label :class="$style.inputLabel" for="new-packing-list-name">
+        <label :class="$style.inputLabel" :for="nameInputId">
           List name
         </label>
 
@@ -40,7 +40,7 @@
           <Icon name="hugeicons:check-list" :class="$style.inputIcon" aria-hidden="true" />
 
           <input
-            id="new-packing-list-name"
+            :id="nameInputId"
             ref="nameInput"
             v-model="listName"
             :disabled="loading"
@@ -55,7 +55,7 @@
 
       <p
         v-if="isErrorVisible"
-        id="new-packing-list-create-error"
+        :id="errorId"
         :class="$style.errorMessage"
         role="alert"
       >
@@ -85,7 +85,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, nextTick, useTemplateRef, watch } from 'vue'
+  import { computed, nextTick, useId, useTemplateRef, watch } from 'vue'
   import PerdButton from '~/components/PerdButton.vue'
   import PerdHeading from '~/components/PerdHeading.vue'
   import ModalDialog from '~/components/dialogs/ModalDialog.vue'
@@ -103,6 +103,10 @@
   } = defineProps<Props>()
 
   const emit = defineEmits<Emits>()
+  const componentId = useId()
+  const errorId = `${componentId}-error`
+  const headingId = `${componentId}-heading`
+  const nameInputId = `${componentId}-name-input`
 
   const isOpened = defineModel<boolean>({
     required: true
@@ -113,7 +117,7 @@
   })
 
   const nameInput = useTemplateRef('nameInput')
-  const errorMessageId = computed(() => errorMessage === null ? undefined : 'new-packing-list-create-error')
+  const errorMessageId = computed(() => errorMessage === null ? undefined : errorId)
   const isCreateDisabled = computed(() => listName.value.trim() === '' || loading)
   const isErrorVisible = computed(() => errorMessage !== null)
 

--- a/app/components/packing-lists/PackingListEntryComposer.vue
+++ b/app/components/packing-lists/PackingListEntryComposer.vue
@@ -21,11 +21,11 @@
 
       <div :class="$style.panel" @keydown.esc.prevent.stop="handleEscape">
         <form :class="$style.searchForm" role="search" @submit.prevent="handleSearchSubmit">
-          <label :class="$style.inputLabel" for="packing-list-entry-search">
+          <label :class="$style.inputLabel" :for="searchInputId">
             Find an item
           </label>
 
-          <p id="packing-list-entry-search-hint" :class="$style.inputHint">
+          <p :id="searchHintId" :class="$style.inputHint">
             Search by item, brand, or category. Your text can also become a custom item.
           </p>
 
@@ -33,13 +33,13 @@
             <Icon name="hugeicons:search-01" :class="$style.inputIcon" aria-hidden="true" />
 
             <input
-              id="packing-list-entry-search"
+              :id="searchInputId"
               ref="searchInput"
               v-model="searchQuery"
               :class="$style.input"
               :disabled="isMutationPending"
               :maxlength="maxCustomNameLength"
-              aria-describedby="packing-list-entry-search-hint"
+              :aria-describedby="searchHintId"
               name="search"
               type="text"
               autocomplete="off"
@@ -129,7 +129,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, nextTick, onMounted, useTemplateRef } from 'vue'
+  import { computed, nextTick, onMounted, useId, useTemplateRef } from 'vue'
   import { limits } from '#shared/constants'
   import type { PackingListAvailableGearItem, PackingListEntry } from '~/types/packing'
   import { usePackingListEntryComposer } from '~/composables/use-packing-list-entry-composer'
@@ -154,6 +154,9 @@
   } = defineProps<Props>()
 
   const emit = defineEmits<Emits>()
+  const componentId = useId()
+  const searchHintId = `${componentId}-search-hint`
+  const searchInputId = `${componentId}-search-input`
   const detailsRef = useTemplateRef('details')
   const summaryRef = useTemplateRef('summary')
   const searchInput = useTemplateRef('searchInput')

--- a/app/components/perd-select/PerdSelect.vue
+++ b/app/components/perd-select/PerdSelect.vue
@@ -17,6 +17,7 @@
       :data-value="modelValue"
       :aria-busy="pending"
       :aria-disabled="ariaDisabled"
+      :aria-required="ariaRequired"
       :aria-controls="listboxId"
       :aria-expanded="isOpen"
       :aria-activedescendant="activeOptionId"
@@ -81,13 +82,15 @@
     label: string;
     options: PerdSelectOption[];
     pending?: boolean;
+    required?: boolean;
   }
 
   const {
     disabled,
     label,
     options,
-    pending
+    pending,
+    required
   } = defineProps<Props>()
 
   const modelValue = defineModel<string>({
@@ -122,6 +125,7 @@
   const isNativelyDisabled = computed(() => disabled === true || hasEnabledOptions.value === false)
   const isControlDisabled = computed(() => isNativelyDisabled.value || pending === true)
   const ariaDisabled = computed(() => pending === true || undefined)
+  const ariaRequired = computed(() => required === true || undefined)
 
   const selectedOption = computed(() => (
     options.find((option) => option.value === modelValue.value)

--- a/app/composables/use-user-state.ts
+++ b/app/composables/use-user-state.ts
@@ -4,6 +4,7 @@ import { useFetch, useState } from '#imports'
 interface User {
   userId: string | null;
   isAdmin: boolean;
+  isGuest: boolean;
   hasData: boolean;
 }
 
@@ -12,6 +13,7 @@ export function useUserStore() {
     return {
       userId: null,
       isAdmin: false,
+      isGuest: false,
       hasData: false
     }
   })
@@ -24,6 +26,7 @@ export function useUserStore() {
     if (data.value?.userId !== undefined) {
       user.value.userId = data.value.userId
       user.value.isAdmin = data.value.isAdmin
+      user.value.isGuest = data.value.isGuest
     }
 
     user.value.hasData = true
@@ -32,6 +35,7 @@ export function useUserStore() {
   function resetAuthentication() {
     user.value.userId = null
     user.value.isAdmin = false
+    user.value.isGuest = false
   }
 
   return {

--- a/app/pages/auth/twitch.vue
+++ b/app/pages/auth/twitch.vue
@@ -65,6 +65,7 @@
 
       user.value.userId = result.userId
       user.value.isAdmin = result.isAdmin
+      user.value.isGuest = result.isGuest
       user.value.hasData = true
 
       const navigationTarget = getRedirectNavigationTarget(route.query.state)

--- a/app/pages/gear-library/index.vue
+++ b/app/pages/gear-library/index.vue
@@ -1,5 +1,15 @@
 <template>
   <PageContent :page-title="navigationLabels.gearLibrary">
+    <template #actions>
+      <PerdButton
+        :to="appRoutes.gearLibraryNew"
+        size="small"
+        icon="hugeicons:add-01"
+      >
+        Submit gear
+      </PerdButton>
+    </template>
+
     <div :class="$style.component">
       <p
         v-if="showPageComparisonNotice"
@@ -66,7 +76,15 @@
 
         <template #results-summary>
           <PageSummaryHeader
-            v-if="hasSuccessfulItemsRequest"
+            v-if="showInitialLoadingSurface"
+            :class="$style.resultsSummaryPlaceholder"
+            label="Results"
+            value="0 items"
+            aria-hidden="true"
+          />
+
+          <PageSummaryHeader
+            v-else-if="hasSuccessfulItemsRequest"
             label="Results"
             :value="itemsSummaryText"
           />
@@ -76,6 +94,7 @@
           <PerdButton
             v-if="showComparisonModeAction"
             ref="comparisonModeAction"
+            size="small"
             variant="secondary"
             @click="handleComparisonModeToggle"
           >
@@ -251,7 +270,7 @@
   import { useGearLibraryStore } from '~/stores/gear-library'
   import { useGearLibraryBrowsingRestoration } from '~/composables/use-gear-library-browsing-restoration'
   import { createGearLibraryAppliedFilterChips } from '~/utils/gear-library-filters'
-  import { createGearLibraryItemPath, navigationLabels } from '~/utils/navigation'
+  import { appRoutes, createGearLibraryItemPath, navigationLabels } from '~/utils/navigation'
   import PagePlaceholder from '~/components/PagePlaceholder.vue'
   import PageSummaryHeader from '~/components/PageSummaryHeader.vue'
   import PerdButton from '~/components/PerdButton.vue'
@@ -692,6 +711,10 @@
   .results {
     display: grid;
     gap: var(--spacing-24);
+  }
+
+  .resultsSummaryPlaceholder {
+    visibility: hidden;
   }
 
   .initialState {

--- a/app/pages/gear-library/new.vue
+++ b/app/pages/gear-library/new.vue
@@ -1,0 +1,725 @@
+<template>
+  <PageContent page-title="Submit missing gear">
+    <template v-if="showFormBackLink" #actions>
+      <PerdLink :to="appRoutes.gearLibrary">
+        Back to Gear library
+      </PerdLink>
+    </template>
+
+    <PagePlaceholder
+      v-if="isGuest"
+      emoji="🔐"
+      title="Account required."
+    >
+      Guest accounts cannot submit gear for review. Account upgrade options will be available later.
+    </PagePlaceholder>
+
+    <div v-else :class="$style.component">
+      <div v-if="isSubmitted" :class="$style.confirmation">
+        <p
+          ref="confirmationStatus"
+          role="status"
+          tabindex="-1"
+        >
+          Submitted for review. It will not appear in Gear library, My gear, or packing lists until an administrator approves it.
+        </p>
+
+        <div :class="$style.actions">
+          <PerdButton @click="startAnotherSubmission">
+            Submit another item
+          </PerdButton>
+
+          <PerdLink :to="appRoutes.gearLibrary">
+            Back to Gear library
+          </PerdLink>
+        </div>
+      </div>
+
+      <form v-else :class="$style.form" @submit.prevent="handleSubmit">
+        <div
+          v-if="hasMandatoryReferenceError"
+          :class="$style.alert"
+          role="alert"
+        >
+          <span>Could not load brands and categories.</span>
+
+          <PerdButton
+            size="small"
+            variant="secondary"
+            :loading="isMandatoryReferenceLoading"
+            @click="retryMandatoryReferences"
+          >
+            Retry
+          </PerdButton>
+        </div>
+
+        <div :class="$style.baseFields" :aria-busy="mandatoryAriaBusy">
+          <TextInput
+            ref="itemNameInput"
+            v-model="itemName"
+            label="Item name"
+            name="name"
+            placeholder="PocketRocket Deluxe"
+            :disabled="isSubmitting"
+            :maxlength="maxItemNameLength"
+            required
+          />
+
+          <PerdSelect
+            v-model="selectedBrandId"
+            label="Brand"
+            :options="brandOptions"
+            :disabled="isMandatorySelectDisabled"
+            :pending="isMandatoryReferenceLoading"
+            required
+          />
+
+          <PerdSelect
+            v-model="selectedCategorySlug"
+            label="Category"
+            :options="categoryOptions"
+            :disabled="isMandatorySelectDisabled"
+            :pending="isMandatoryReferenceLoading"
+            required
+          />
+        </div>
+
+        <section
+          v-if="hasSelectedCategory"
+          :class="$style.properties"
+          :aria-labelledby="knownPropertiesTitleId"
+        >
+          <div :class="$style.sectionHeading">
+            <h2 :id="knownPropertiesTitleId" :class="$style.heading">
+              Known characteristics
+            </h2>
+
+            <span v-if="isCategoryDetailLoading" :class="$style.muted" role="status">
+              Loading characteristics…
+            </span>
+          </div>
+
+          <div
+            v-if="hasCategoryDetailError"
+            :class="$style.alert"
+            role="alert"
+          >
+            <span>Could not load characteristics. You can still submit the basic item.</span>
+
+            <PerdButton
+              size="small"
+              variant="secondary"
+              :loading="isCategoryDetailLoading"
+              @click="retryCategoryDetail"
+            >
+              Retry
+            </PerdButton>
+          </div>
+
+          <div v-else-if="hasPropertyFields" :class="$style.propertyFields">
+            <template v-for="property in propertyFields" :key="property.id">
+              <TextInput
+                v-if="property.isText"
+                :model-value="property.value"
+                :label="property.label"
+                :disabled="isSubmitting"
+                :name="property.inputName"
+                @update:model-value="property.setValue"
+              />
+
+              <NumberInput
+                v-else-if="property.isNumber"
+                :model-value="property.value"
+                :label="property.label"
+                :disabled="isSubmitting"
+                :error="property.error"
+                :name="property.inputName"
+                :unit="property.unit"
+                @update:model-value="property.setValue"
+              />
+
+              <PerdSelect
+                v-else-if="property.isEnum"
+                :model-value="property.value"
+                :label="property.label"
+                :options="property.enumOptions"
+                :disabled="isSubmitting"
+                @update:model-value="property.setValue"
+              />
+
+              <PerdSelect
+                v-else
+                :model-value="property.value"
+                :label="property.label"
+                :options="booleanOptions"
+                :disabled="isSubmitting"
+                @update:model-value="property.setValue"
+              />
+            </template>
+          </div>
+
+          <p v-else-if="showNoPropertiesMessage" :class="$style.muted">
+            This category has no characteristics yet.
+          </p>
+        </section>
+
+        <p v-if="hasSubmitError" :class="$style.errorMessage" role="alert">
+          Could not submit item. Try again.
+        </p>
+
+        <div :class="$style.actions">
+          <PerdButton
+            type="submit"
+            :disabled="isSubmitDisabled"
+            :loading="isSubmitting"
+          >
+            Submit for review
+          </PerdButton>
+        </div>
+      </form>
+    </div>
+  </PageContent>
+</template>
+
+<script lang="ts" setup>
+  /* oxlint-disable max-lines -- The single submission page owns its one-off form, request, and field state. */
+  import { computed, nextTick, onBeforeUnmount, ref, useId, useTemplateRef, watch } from 'vue'
+  import { definePageMeta, useFetch, useRequestFetch, useUserStore } from '#imports'
+  import { limits } from '#shared/constants'
+  import { isFiniteDecimalNumber } from '#shared/utils/decimal-number'
+  import type { CategoryDetailResponse } from '#server/api/equipment/categories/by-slug/[slug].get'
+  import { appRoutes } from '~/utils/navigation'
+  import NumberInput from '~/components/NumberInput.vue'
+  import PagePlaceholder from '~/components/PagePlaceholder.vue'
+  import PageContent from '~/components/layout/PageContent.vue'
+  import PerdButton from '~/components/PerdButton.vue'
+  import PerdLink from '~/components/PerdLink.vue'
+  import PerdSelect, { type PerdSelectOption } from '~/components/perd-select/PerdSelect.vue'
+  import TextInput from '~/components/TextInput.vue'
+
+  interface ItemSubmissionPropertyInput {
+    propertyId: number;
+    value: boolean | string;
+  }
+
+  interface ItemSubmissionCreateBody {
+    brandId: number;
+    categoryId: number;
+    name: string;
+    properties: ItemSubmissionPropertyInput[];
+  }
+
+  interface PropertyFieldView {
+    enumOptions: PerdSelectOption[];
+    error?: string;
+    id: number;
+    inputName: string;
+    isEnum: boolean;
+    isNumber: boolean;
+    isText: boolean;
+    label: string;
+    setValue: (value: string) => void;
+    unit: string | null;
+    value: string;
+  }
+
+  definePageMeta({
+    layout: 'page'
+  })
+
+  const requestFetch = useRequestFetch()
+  const { user } = useUserStore()
+  const isGuest = computed(() => user.value.isGuest)
+  const knownPropertiesTitleId = useId()
+  const confirmationStatus = useTemplateRef('confirmationStatus')
+  const itemNameInput = useTemplateRef('itemNameInput')
+  const maxItemNameLength = limits.maxEquipmentItemNameLength
+  const itemName = ref('')
+  const selectedBrandId = ref('')
+  const selectedCategorySlug = ref('')
+  const categoryDetail = ref<CategoryDetailResponse | null>(null)
+  const categoryDetailError = ref(false)
+  const isCategoryDetailLoading = ref(false)
+  const isSubmitting = ref(false)
+  const isSubmitted = ref(false)
+  const submitError = ref(false)
+  const propertyValues = ref<Record<number, unknown>>({})
+  const propertyErrors = ref<Record<number, boolean>>({})
+  let categoryRequestController: InstanceType<typeof globalThis.AbortController> | null = null
+  let categoryRequestSequence = 0
+
+  const brandsRequestPromise = useFetch('/api/equipment/brands', {
+    default: () => [],
+    immediate: isGuest.value === false,
+    key: 'item-submission-brands'
+  })
+
+  const categoriesRequestPromise = useFetch('/api/equipment/categories', {
+    default: () => [],
+    immediate: isGuest.value === false,
+    key: 'item-submission-categories'
+  })
+
+  const [brandsRequest, categoriesRequest] = await Promise.all([
+    brandsRequestPromise,
+    categoriesRequestPromise
+  ])
+
+  const {
+    data: brandsResponse,
+    error: brandsError,
+    refresh: refreshBrands,
+    status: brandsStatus
+  } = brandsRequest
+
+  const {
+    data: categoriesResponse,
+    error: categoriesError,
+    refresh: refreshCategories,
+    status: categoriesStatus
+  } = categoriesRequest
+
+  const booleanOptions = [
+    {
+      label: 'Not specified',
+      value: ''
+    },
+    {
+      label: 'Yes',
+      value: 'true'
+    },
+    {
+      label: 'No',
+      value: 'false'
+    }
+  ]
+
+  const brandOptions = computed<PerdSelectOption[]>(() => {
+    const options = brandsResponse.value.map((brand) => {
+      return {
+        label: brand.name,
+        value: `${brand.id}`
+      }
+    })
+
+    const defaultOption = {
+      label: 'Select a brand',
+      value: ''
+    }
+
+    return [
+      defaultOption,
+      ...options
+    ]
+  })
+
+  const categoryOptions = computed<PerdSelectOption[]>(() => {
+    const options = categoriesResponse.value.map((category) => {
+      return {
+        label: category.name,
+        value: category.slug
+      }
+    })
+
+    const defaultOption = {
+      label: 'Select a category',
+      value: ''
+    }
+
+    return [
+      defaultOption,
+      ...options
+    ]
+  })
+
+  const hasMandatoryReferenceError = computed(() => (
+    brandsError.value !== undefined || categoriesError.value !== undefined
+  ))
+
+  const isMandatoryReferenceLoading = computed(() => (
+    brandsStatus.value === 'pending' || categoriesStatus.value === 'pending'
+  ))
+
+  const isMandatoryReferenceReady = computed(() => (
+    brandsStatus.value === 'success' && categoriesStatus.value === 'success'
+  ))
+
+  const isMandatorySelectDisabled = computed(() => (
+    isSubmitting.value || isMandatoryReferenceReady.value === false
+  ))
+
+  const mandatoryAriaBusy = computed(() => isMandatoryReferenceLoading.value || undefined)
+  const hasSelectedCategory = computed(() => selectedCategorySlug.value !== '')
+  const hasCategoryDetailError = computed(() => categoryDetailError.value)
+
+  const selectedBrand = computed(() => {
+    const brandId = Number(selectedBrandId.value)
+    const brands = brandsResponse.value
+
+    return brands.find((brand) => brand.id === brandId)
+  })
+
+  const selectedCategory = computed(() => {
+    const categories = categoriesResponse.value
+
+    return categories.find((category) => category.slug === selectedCategorySlug.value)
+  })
+
+  function getPropertyFieldValue(rawValue: unknown) {
+    if (typeof rawValue === 'string') {
+      return rawValue
+    }
+
+    if (typeof rawValue === 'number') {
+      const isFiniteNumber = Number.isFinite(rawValue)
+
+      if (isFiniteNumber === false) {
+        return ''
+      }
+
+      return `${rawValue}`
+    }
+
+    if (typeof rawValue === 'boolean') {
+      if (rawValue) {
+        return 'true'
+      }
+
+      return 'false'
+    }
+
+    return ''
+  }
+
+  const propertyFields = computed<PropertyFieldView[]>(() => {
+    const properties = categoryDetail.value?.properties ?? []
+
+    return properties.map((property) => {
+      const propertyEnumOptions = property.enumOptions ?? []
+
+      const mappedEnumOptions = propertyEnumOptions.map((option) => {
+        return {
+          label: option.name,
+          value: option.slug
+        }
+      })
+
+      const enumOptions = [
+        {
+          label: 'Not specified',
+          value: ''
+        },
+        ...mappedEnumOptions
+      ]
+
+      const rawValue = propertyValues.value[property.id]
+      const value = getPropertyFieldValue(rawValue)
+      const hasError = propertyErrors.value[property.id] === true
+      const error = hasError ? 'Enter a valid decimal number.' : undefined
+
+      function setValue(nextValue: string) {
+        propertyValues.value[property.id] = nextValue
+      }
+
+      return {
+        enumOptions,
+        error,
+        id: property.id,
+        inputName: `property-${property.id}`,
+        isEnum: property.dataType === 'enum',
+        isNumber: property.dataType === 'number',
+        isText: property.dataType === 'text',
+        label: property.name,
+        setValue,
+        unit: property.unit,
+        value
+      }
+    })
+  })
+
+  const hasPropertyFields = computed(() => propertyFields.value.length > 0)
+
+  const showNoPropertiesMessage = computed(() => (
+    isCategoryDetailLoading.value === false
+    && categoryDetailError.value === false
+    && categoryDetail.value !== null
+  ))
+
+  const hasSubmitError = computed(() => submitError.value)
+  const showFormBackLink = computed(() => isGuest.value || isSubmitted.value === false)
+  const trimmedItemName = computed(() => itemName.value.trim())
+
+  const isSubmitDisabled = computed(() => (
+    trimmedItemName.value === ''
+    || selectedBrand.value === undefined
+    || selectedCategory.value === undefined
+    || isMandatoryReferenceReady.value === false
+    || isSubmitting.value
+  ))
+
+  function clearPropertyState() {
+    propertyValues.value = {}
+    propertyErrors.value = {}
+  }
+
+  async function startAnotherSubmission() {
+    itemName.value = ''
+    selectedBrandId.value = ''
+    selectedCategorySlug.value = ''
+    categoryDetail.value = null
+    categoryDetailError.value = false
+    submitError.value = false
+
+    clearPropertyState()
+
+    isSubmitted.value = false
+
+    await nextTick()
+
+    itemNameInput.value?.focus()
+  }
+
+  async function loadCategoryDetail(categorySlug: string) {
+    categoryRequestController?.abort()
+    categoryRequestSequence += 1
+
+    const requestSequence = categoryRequestSequence
+
+    clearPropertyState()
+
+    categoryDetail.value = null
+    categoryDetailError.value = false
+
+    if (categorySlug === '') {
+      isCategoryDetailLoading.value = false
+
+      return
+    }
+
+    const controller = new globalThis.AbortController()
+
+    categoryRequestController = controller
+    isCategoryDetailLoading.value = true
+
+    try {
+      const categoryDetailPath = `/api/equipment/categories/by-slug/${categorySlug}` as const
+
+      const response = await requestFetch(categoryDetailPath, {
+        signal: controller.signal
+      })
+
+      const isCurrentRequest = requestSequence === categoryRequestSequence
+
+      if (isCurrentRequest) {
+        categoryDetail.value = response
+      }
+    } catch {
+      const isCurrentRequest = requestSequence === categoryRequestSequence
+
+      if (controller.signal.aborted === false && isCurrentRequest) {
+        categoryDetailError.value = true
+      }
+    } finally {
+      const isCurrentRequest = requestSequence === categoryRequestSequence
+
+      if (isCurrentRequest) {
+        isCategoryDetailLoading.value = false
+      }
+    }
+  }
+
+  async function retryMandatoryReferences() {
+    const refreshBrandsPromise = refreshBrands()
+    const refreshCategoriesPromise = refreshCategories()
+
+    await Promise.all([
+      refreshBrandsPromise,
+      refreshCategoriesPromise
+    ])
+  }
+
+  async function retryCategoryDetail() {
+    await loadCategoryDetail(selectedCategorySlug.value)
+  }
+
+  function createSubmissionProperties() {
+    const properties: ItemSubmissionPropertyInput[] = []
+    const categoryProperties = categoryDetail.value?.properties ?? []
+    let hasValidationError = false
+
+    for (const property of categoryProperties) {
+      const rawValue = propertyValues.value[property.id]
+      const fieldValue = getPropertyFieldValue(rawValue)
+      const trimmedValue = fieldValue.trim()
+      const hasValue = trimmedValue !== ''
+      const isNumberProperty = property.dataType === 'number'
+
+      propertyErrors.value[property.id] = false
+
+      if (hasValue && isNumberProperty) {
+        const hasValidNumber = isFiniteDecimalNumber(trimmedValue)
+
+        if (hasValidNumber === false) {
+          propertyErrors.value[property.id] = true
+          hasValidationError = true
+        }
+      }
+
+      const hasPropertyError = propertyErrors.value[property.id] === true
+      const isPropertyValid = hasValue && hasPropertyError === false
+
+      if (isPropertyValid) {
+        const isBooleanProperty = property.dataType === 'boolean'
+        let value: boolean | string = trimmedValue
+
+        if (isBooleanProperty) {
+          value = trimmedValue === 'true'
+        }
+
+        properties.push({
+          propertyId: property.id,
+          value
+        })
+      }
+    }
+
+    return {
+      hasValidationError,
+      properties
+    }
+  }
+
+  async function handleSubmit() {
+    if (isSubmitDisabled.value) {
+      return
+    }
+
+    const brand = selectedBrand.value
+    const category = selectedCategory.value
+
+    if (brand === undefined || category === undefined) {
+      return
+    }
+
+    const submissionProperties = createSubmissionProperties()
+
+    if (submissionProperties.hasValidationError) {
+      return
+    }
+
+    const body: ItemSubmissionCreateBody = {
+      brandId: brand.id,
+      categoryId: category.id,
+      name: trimmedItemName.value,
+      properties: submissionProperties.properties
+    }
+
+    submitError.value = false
+    isSubmitting.value = true
+
+    try {
+      await requestFetch('/api/equipment/item-submissions', {
+        body,
+        method: 'POST'
+      })
+
+      isSubmitted.value = true
+
+      await nextTick()
+
+      confirmationStatus.value?.focus()
+    } catch {
+      submitError.value = true
+    } finally {
+      isSubmitting.value = false
+    }
+  }
+
+  watch(selectedCategorySlug, (categorySlug) => {
+    void loadCategoryDetail(categorySlug)
+  })
+
+  onBeforeUnmount(() => {
+    categoryRequestController?.abort()
+  })
+</script>
+
+<style module>
+  .component {
+    display: grid;
+    container-type: inline-size;
+  }
+
+  .form {
+    display: grid;
+    gap: var(--spacing-24);
+    max-inline-size: 54rem;
+  }
+
+  .baseFields {
+    display: grid;
+    gap: var(--spacing-16);
+
+    @container (inline-size >= 42rem) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  .properties,
+  .propertyFields {
+    display: grid;
+    gap: var(--spacing-16);
+  }
+
+  .sectionHeading {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--spacing-8);
+  }
+
+  .heading {
+    font-size: var(--font-size-20);
+    line-height: var(--line-height-snug);
+  }
+
+  .alert {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-12);
+    padding: var(--spacing-12);
+    border: 1px solid var(--color-border-strong);
+    border-radius: var(--border-radius-12);
+    background-color: var(--color-surface-secondary);
+  }
+
+  .errorMessage {
+    color: var(--color-danger-primary);
+  }
+
+  .muted {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-14);
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: flex-start;
+    gap: var(--spacing-12);
+  }
+
+  .confirmation {
+    display: grid;
+    gap: var(--spacing-16);
+    max-inline-size: 44rem;
+    padding: var(--spacing-24);
+    border: 1px solid var(--color-border-subtle);
+    border-radius: var(--border-radius-16);
+    background-color: var(--color-surface-secondary);
+  }
+</style>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -137,6 +137,7 @@
 
       if (typeof response.userId === 'string') {
         user.value.userId = response.userId
+        user.value.isGuest = response.isGuest
         user.value.hasData = true
       }
 

--- a/app/utils/navigation.ts
+++ b/app/utils/navigation.ts
@@ -1,6 +1,7 @@
 const appRoutes = {
   account: '/account',
   gearLibrary: '/gear-library',
+  gearLibraryNew: '/gear-library/new',
   home: '/',
   myGear: '/my-gear',
   packingLists: '/packing-lists'

--- a/server/api/auth/__tests__/create-session.test.ts
+++ b/server/api/auth/__tests__/create-session.test.ts
@@ -1,0 +1,66 @@
+import type * as h3 from 'h3'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import createGuestSessionHandler from '#server/api/auth/create-session.post'
+import { users } from '#server/database/schema'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+const { setResponseStatusMock, sessionUpdateMock, useAppSessionMock } = vi.hoisted(() => {
+  return {
+    setResponseStatusMock: vi.fn<typeof h3.setResponseStatus>(),
+    sessionUpdateMock: vi.fn(),
+    useAppSessionMock: vi.fn()
+  }
+})
+
+vi.mock(import('h3'), async () => {
+  const actual = await vi.importActual<typeof h3>('h3')
+
+  return {
+    ...actual,
+
+    setResponseStatus(...args: Parameters<typeof h3.setResponseStatus>) {
+      setResponseStatusMock(...args)
+    }
+  }
+})
+
+vi.mock(import('#server/utils/session'), () => {
+  return {
+    useAppSession: useAppSessionMock
+  }
+})
+
+describe('post /api/auth/create-session', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should create and return an explicit Guest account', async () => {
+    const returningMock = vi.fn(() => [{
+      userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
+    }])
+    const valuesMock = vi.fn(() => {
+      return { returning: returningMock }
+    })
+    const insertMock = vi.fn((table: unknown) => {
+      expect(table).toBe(users)
+
+      return { values: valuesMock }
+    })
+    const event = createTestEvent({ insert: insertMock })
+
+    useAppSessionMock.mockResolvedValue({ update: sessionUpdateMock })
+
+    const result = await createGuestSessionHandler(event)
+
+    expect(valuesMock).toHaveBeenCalledWith({})
+    expect(sessionUpdateMock).toHaveBeenCalledWith({
+      userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
+    })
+    expect(setResponseStatusMock).toHaveBeenCalledWith(event, 201)
+    expect(result).toStrictEqual({
+      isGuest: true,
+      userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
+    })
+  })
+})

--- a/server/api/auth/create-session.post.ts
+++ b/server/api/auth/create-session.post.ts
@@ -3,6 +3,7 @@ import { users } from '#server/database/schema'
 import { useAppSession } from '#server/utils/session'
 
 interface ReturnType {
+  isGuest: boolean;
   userId: string;
 }
 
@@ -34,6 +35,7 @@ export default defineEventHandler(async (event) : Promise<ReturnType> => {
   })
 
   return {
+    isGuest: true,
     userId: newUser.userId
   }
 })

--- a/server/api/equipment/categories/[categoryId]/properties/[propertyId]/enum-options/[optionId]/index.delete.ts
+++ b/server/api/equipment/categories/[categoryId]/properties/[propertyId]/enum-options/[optionId]/index.delete.ts
@@ -31,6 +31,7 @@ export default defineEventHandler(async (event) => {
           )
         )
         .limit(1)
+        .for('update')
 
       if (currentOption === undefined) {
         throw createError({ status: 404 })

--- a/server/api/equipment/categories/__tests__/property-enum-options.test.ts
+++ b/server/api/equipment/categories/__tests__/property-enum-options.test.ts
@@ -22,6 +22,7 @@ interface MockWriteDb {
 
 interface SelectOperation {
   error?: Error;
+  lock?: boolean;
   rows: unknown;
 }
 
@@ -84,6 +85,8 @@ vi.mock(import('#server/utils/config'), () => {
 })
 
 function createSelectMock(operations: SelectOperation[]) {
+  const forMocks: ReturnType<typeof vi.fn>[] = []
+
   const whereMock = vi.fn(() => {
     const operation = operations.shift()
 
@@ -91,14 +94,24 @@ function createSelectMock(operations: SelectOperation[]) {
       throw new Error('No select operation configured')
     }
 
-    return {
-      limit: vi.fn(() => {
-        if (operation.error !== undefined) {
-          throw operation.error
-        }
+    const limitMock = vi.fn(() => {
+      if (operation.error !== undefined) {
+        throw operation.error
+      }
 
-        return operation.rows
-      })
+      if (operation.lock === true) {
+        const forMock = vi.fn(() => operation.rows)
+
+        forMocks.push(forMock)
+
+        return { for: forMock }
+      }
+
+      return operation.rows
+    })
+
+    return {
+      limit: limitMock
     }
   })
 
@@ -122,6 +135,7 @@ function createSelectMock(operations: SelectOperation[]) {
   })
 
   return {
+    forMocks,
     selectMock
   }
 }
@@ -421,7 +435,8 @@ describe('property enum option handlers', () => {
         type: 'values'
       }])
 
-      const { selectMock } = createSelectMock([{
+      const { forMocks, selectMock } = createSelectMock([{
+        lock: true,
         rows: [deletedOption]
       }, {
         rows: []
@@ -442,6 +457,18 @@ describe('property enum option handlers', () => {
       const event = createTestEvent({})
       await deletePropertyEnumOptionHandler(event)
 
+      const [propertyLockMock] = forMocks
+
+      expect(forMocks).toHaveLength(1)
+      expect(propertyLockMock).toHaveBeenCalledWith('update')
+      expect(selectMock).toHaveBeenCalledTimes(2)
+
+      const propertyLockCallOrder = Math.min(
+        ...forMocks.flatMap((forMock) => forMock.mock.invocationCallOrder)
+      )
+      const usageReadCallOrder = Math.max(...selectMock.mock.invocationCallOrder)
+
+      expect(propertyLockCallOrder).toBeLessThan(usageReadCallOrder)
       expect(setResponseStatusMock).toHaveBeenCalledWith(event, 204)
       expect(valuesMocks[0]).toHaveBeenCalledWith({
         action: 'delete_property_enum_option',
@@ -461,6 +488,7 @@ describe('property enum option handlers', () => {
     it('should return 404 when category property does not exist', async () => {
       const { insertMock } = createInsertMock([])
       const { selectMock } = createSelectMock([{
+        lock: true,
         rows: []
       }])
 
@@ -488,6 +516,7 @@ describe('property enum option handlers', () => {
     it('should return 404 when property enum option does not belong to property', async () => {
       const { insertMock } = createInsertMock([])
       const { selectMock } = createSelectMock([{
+        lock: true,
         rows: []
       }])
 
@@ -521,6 +550,7 @@ describe('property enum option handlers', () => {
 
       const { insertMock } = createInsertMock([])
       const { selectMock } = createSelectMock([{
+        lock: true,
         rows: [deletedOption]
       }, {
         rows: [{

--- a/server/api/equipment/item-submissions/__tests__/create.test.ts
+++ b/server/api/equipment/item-submissions/__tests__/create.test.ts
@@ -1,0 +1,400 @@
+import * as h3 from 'h3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { categoryProperties, contributions, equipmentItems, itemPropertyValues } from '#server/database/schema'
+import createItemSubmissionHandler from '#server/api/equipment/item-submissions/index.post'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+const {
+  createWebSocketClientMock,
+  readValidatedBodyMock,
+  setResponseStatusMock,
+  validateRegisteredUserMock
+} = vi.hoisted(() => {
+  return {
+    createWebSocketClientMock: vi.fn(),
+    readValidatedBodyMock: vi.fn<typeof h3.readValidatedBody>(),
+    setResponseStatusMock: vi.fn<typeof h3.setResponseStatus>(),
+    validateRegisteredUserMock: vi.fn<(event: unknown) => Promise<string>>()
+  }
+})
+
+// @ts-expect-error -- Vitest's import-based module mock typing rejects this partial h3 mock.
+vi.mock(import('h3'), async () => {
+  const actual = await vi.importActual<typeof h3>('h3')
+
+  return {
+    ...actual,
+
+    async readValidatedBody(...args: Parameters<typeof h3.readValidatedBody>) {
+      return readValidatedBodyMock(...args)
+    },
+
+    setResponseStatus(...args: Parameters<typeof h3.setResponseStatus>) {
+      setResponseStatusMock(...args)
+    }
+  }
+})
+
+vi.mock(import('#server/utils/user'), () => {
+  return {
+    validateRegisteredUser: validateRegisteredUserMock
+  }
+})
+
+vi.mock(import('#server/utils/config'), () => {
+  return {
+    createWebSocketClientFromEvent: createWebSocketClientMock
+  }
+})
+
+interface CreateDbOptions {
+  brand?: unknown;
+  category?: unknown;
+  contributionError?: Error;
+  createdItemId?: string;
+}
+
+function createDb(options: CreateDbOptions = {}) {
+  const defaultCategory = {
+    id: 2,
+    name: 'Stoves',
+
+    properties: [{
+      allowsNegativeValues: false,
+      categoryId: 2,
+      dataType: 'number',
+      enumOptions: [],
+      id: 3
+    }, {
+      allowsNegativeValues: false,
+      categoryId: 2,
+      dataType: 'boolean',
+      enumOptions: [],
+      id: 4
+    }]
+  }
+  const brand = 'brand' in options ? options.brand : { id: 1, name: 'MSR' }
+  const category = 'category' in options ? options.category : defaultCategory
+  const { contributionError } = options
+  const createdItemId = options.createdItemId ?? '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
+  const itemReturningMock = vi.fn(() => [{ id: createdItemId }])
+  const itemValuesMock = vi.fn(() => {
+    return { returning: itemReturningMock }
+  })
+  const propertyValuesMock = vi.fn()
+  const contributionValuesMock = vi.fn(() => {
+    if (contributionError !== undefined) {
+      throw contributionError
+    }
+  })
+  const insertMock = vi.fn()
+  const propertyLockForMock = vi.fn(() => [])
+  const propertyLockWhereMock = vi.fn(() => {
+    return { for: propertyLockForMock }
+  })
+  const propertyLockFromMock = vi.fn(() => {
+    return { where: propertyLockWhereMock }
+  })
+  const selectMock = vi.fn(() => {
+    return { from: propertyLockFromMock }
+  })
+
+  insertMock.mockImplementation((table: unknown) => {
+    if (table === equipmentItems) {
+      return { values: itemValuesMock }
+    }
+
+    if (table === itemPropertyValues) {
+      return { values: propertyValuesMock }
+    }
+
+    if (table === contributions) {
+      return { values: contributionValuesMock }
+    }
+
+    throw new Error('Unexpected insert table')
+  })
+
+  const transaction = {
+    insert: insertMock,
+    select: selectMock,
+
+    query: {
+      brands: {
+        findFirst: vi.fn(() => brand)
+      },
+
+      equipmentCategories: {
+        findFirst: vi.fn(() => category)
+      }
+    }
+  }
+
+  const transactionMock = vi.fn(
+    async (execute: (transactionValue: typeof transaction) => Promise<unknown>) => execute(transaction)
+  )
+  const endMock = vi.fn()
+  const dbWrite = {
+    $client: {
+      end: endMock
+    },
+
+    transaction: transactionMock
+  }
+
+  return {
+    contributionValuesMock,
+    dbWrite,
+    insertMock,
+    itemValuesMock,
+    propertyLockForMock,
+    propertyLockFromMock,
+    propertyValuesMock,
+    selectMock,
+    transaction
+  }
+}
+
+describe('post /api/equipment/item-submissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    validateRegisteredUserMock.mockResolvedValue('user-1')
+
+    readValidatedBodyMock.mockResolvedValue({
+      brandId: 1,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+      properties: []
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should create a pending item and contribution without creating My gear', async () => {
+    const { contributionValuesMock, dbWrite, insertMock, itemValuesMock, transaction } = createDb()
+
+    createWebSocketClientMock.mockReturnValue(dbWrite)
+
+    const event = createTestEvent({})
+    const result = await createItemSubmissionHandler(event)
+
+    expect(result).toStrictEqual({
+      id: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+      status: 'pending'
+    })
+    expect(setResponseStatusMock).toHaveBeenCalledWith(event, 201)
+    expect(transaction.query.brands.findFirst).toHaveBeenCalledWith({
+      columns: {
+        id: true,
+        name: true
+      },
+
+      where: {
+        id: 1
+      }
+    })
+    expect(transaction.query.equipmentCategories.findFirst).toHaveBeenCalledWith({
+      columns: {
+        id: true,
+        name: true
+      },
+
+      where: {
+        id: 2
+      },
+
+      with: {
+        properties: {
+          columns: {
+            allowsNegativeValues: true,
+            categoryId: true,
+            dataType: true,
+            id: true
+          },
+
+          with: {
+            enumOptions: {
+              columns: {
+                slug: true
+              }
+            }
+          }
+        }
+      }
+    })
+
+    expect(itemValuesMock).toHaveBeenCalledWith({
+      brandId: 1,
+      categoryId: 2,
+      createdBy: 'user-1',
+      name: 'PocketRocket Deluxe',
+      status: 'pending'
+    })
+
+    expect(contributionValuesMock).toHaveBeenCalledWith({
+      action: 'submit_equipment_item',
+
+      metadata: {
+        brandId: 1,
+        brandName: 'MSR',
+        categoryId: 2,
+        categoryName: 'Stoves',
+        name: 'PocketRocket Deluxe',
+        propertyCount: 0,
+        status: 'pending'
+      },
+
+      targetId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+      userId: 'user-1'
+    })
+    expect(insertMock).toHaveBeenCalledTimes(2)
+    expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('should insert normalized non-empty properties in the same transaction', async () => {
+    readValidatedBodyMock.mockResolvedValue({
+      brandId: 1,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+
+      properties: [{
+        propertyId: 3,
+        value: '+0083.500'
+      }, {
+        propertyId: 4,
+        value: false
+      }]
+    })
+
+    const {
+      dbWrite,
+      propertyLockForMock,
+      propertyLockFromMock,
+      propertyValuesMock,
+      selectMock,
+      transaction
+    } = createDb()
+
+    createWebSocketClientMock.mockReturnValue(dbWrite)
+
+    await createItemSubmissionHandler(createTestEvent({}))
+
+    expect(selectMock).toHaveBeenCalledWith({
+      id: categoryProperties.id
+    })
+    expect(propertyLockFromMock).toHaveBeenCalledWith(categoryProperties)
+    expect(propertyLockForMock).toHaveBeenCalledWith('key share')
+
+    const propertyLockCallOrder = Math.min(...propertyLockForMock.mock.invocationCallOrder)
+    const categoryReadCallOrder = Math.min(
+      ...transaction.query.equipmentCategories.findFirst.mock.invocationCallOrder
+    )
+
+    expect(propertyLockCallOrder).toBeLessThan(categoryReadCallOrder)
+
+    expect(propertyValuesMock).toHaveBeenCalledWith([{
+      itemId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+      propertyId: 3,
+      valueBoolean: null,
+      valueNumber: '83.5',
+      valueText: null
+    }, {
+      itemId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
+      propertyId: 4,
+      valueBoolean: false,
+      valueNumber: null,
+      valueText: null
+    }])
+  })
+
+  it('should reject a negative property value before inserting the item', async () => {
+    readValidatedBodyMock.mockResolvedValue({
+      brandId: 1,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+
+      properties: [{
+        propertyId: 3,
+        value: '-83.5'
+      }]
+    })
+
+    const { dbWrite, insertMock } = createDb()
+
+    createWebSocketClientMock.mockReturnValue(dbWrite)
+
+    await expect(createItemSubmissionHandler(createTestEvent({}))).rejects.toMatchObject({
+      message: 'Number property value must not be negative',
+      statusCode: 400
+    })
+    expect(insertMock).not.toHaveBeenCalled()
+    expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('should require a session before opening the write client', async () => {
+    const authError = h3.createError({ status: 401 })
+
+    validateRegisteredUserMock.mockRejectedValue(authError)
+
+    await expect(createItemSubmissionHandler(createTestEvent({}))).rejects.toMatchObject({
+      statusCode: 401
+    })
+    expect(readValidatedBodyMock).not.toHaveBeenCalled()
+    expect(createWebSocketClientMock).not.toHaveBeenCalled()
+  })
+
+  it('should reject a Guest before validating the body or opening the write client', async () => {
+    const guestError = h3.createError({ status: 403 })
+
+    validateRegisteredUserMock.mockRejectedValue(guestError)
+
+    await expect(createItemSubmissionHandler(createTestEvent({}))).rejects.toMatchObject({
+      statusCode: 403
+    })
+    expect(readValidatedBodyMock).not.toHaveBeenCalled()
+    expect(createWebSocketClientMock).not.toHaveBeenCalled()
+  })
+
+  it('should validate the body before opening the write client', async () => {
+    const bodyError = h3.createError({ status: 400 })
+
+    readValidatedBodyMock.mockRejectedValue(bodyError)
+
+    await expect(createItemSubmissionHandler(createTestEvent({}))).rejects.toMatchObject({
+      statusCode: 400
+    })
+    expect(createWebSocketClientMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { brand: undefined, category: { id: 2, name: 'Stoves', properties: [] } },
+    { brand: { id: 1, name: 'MSR' }, category: undefined }
+  ])('should return 404 when a selected reference disappears', async (options) => {
+    const { dbWrite } = createDb(options)
+
+    createWebSocketClientMock.mockReturnValue(dbWrite)
+
+    await expect(createItemSubmissionHandler(createTestEvent({}))).rejects.toMatchObject({
+      statusCode: 404
+    })
+    expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)
+  })
+
+  it('should log the original error, return a safe 500, and close the client', async () => {
+    const databaseError = new Error('raw database failure')
+    const consoleErrorMock = vi.spyOn(console, 'error')
+    const { dbWrite } = createDb({ contributionError: databaseError })
+
+    createWebSocketClientMock.mockReturnValue(dbWrite)
+
+    await expect(createItemSubmissionHandler(createTestEvent({}))).rejects.toMatchObject({
+      message: 'Failed to submit equipment item',
+      statusCode: 500
+    })
+    expect(consoleErrorMock).toHaveBeenCalledWith('Failed to submit equipment item', databaseError)
+    expect(dbWrite.$client.end).toHaveBeenCalledTimes(1)
+  })
+})

--- a/server/api/equipment/item-submissions/index.post.ts
+++ b/server/api/equipment/item-submissions/index.post.ts
@@ -1,0 +1,181 @@
+import { and, eq, inArray } from 'drizzle-orm'
+import { createError, defineEventHandler, isError, readValidatedBody, setResponseStatus } from 'h3'
+
+import {
+  categoryProperties,
+  contributions,
+  equipmentItems,
+  itemPropertyValues
+} from '#server/database/schema'
+
+import { createWebSocketClientFromEvent } from '#server/utils/config'
+import { normalizeItemSubmissionProperties } from '#server/utils/equipment/item-submission-properties'
+import { validateRegisteredUser } from '#server/utils/user'
+import { validateItemSubmissionCreateBody } from '#server/utils/validation/schemas'
+
+interface ItemSubmissionCreateResponse {
+  id: string;
+  status: 'pending';
+}
+
+export default defineEventHandler(async (event): Promise<ItemSubmissionCreateResponse> => {
+  const userId = await validateRegisteredUser(event)
+  const body = await readValidatedBody(event, validateItemSubmissionCreateBody)
+  const dbWebsocket = createWebSocketClientFromEvent(event)
+
+  try {
+    const createdSubmission = await dbWebsocket.transaction(async (transaction) => {
+      const submittedPropertyIds = body.properties.map((property) => property.propertyId)
+
+      if (submittedPropertyIds.length > 0) {
+        await transaction
+          .select({
+            id: categoryProperties.id
+          })
+          .from(categoryProperties)
+          .where(
+            and(
+              eq(categoryProperties.categoryId, body.categoryId),
+              inArray(categoryProperties.id, submittedPropertyIds)
+            )
+          )
+          .for('key share')
+      }
+
+      const brandPromise = transaction.query.brands.findFirst({
+        columns: {
+          id: true,
+          name: true
+        },
+
+        where: {
+          id: body.brandId
+        }
+      })
+
+      const categoryPromise = transaction.query.equipmentCategories.findFirst({
+        columns: {
+          id: true,
+          name: true
+        },
+
+        where: {
+          id: body.categoryId
+        },
+
+        with: {
+          properties: {
+            columns: {
+              allowsNegativeValues: true,
+              categoryId: true,
+              dataType: true,
+              id: true
+            },
+
+            with: {
+              enumOptions: {
+                columns: {
+                  slug: true
+                }
+              }
+            }
+          }
+        }
+      })
+
+      const [brand, category] = await Promise.all([
+        brandPromise,
+        categoryPromise
+      ])
+
+      if (brand === undefined || category === undefined) {
+        throw createError({ status: 404 })
+      }
+
+      const normalizedProperties = normalizeItemSubmissionProperties(
+        body.categoryId,
+        category.properties,
+        body.properties
+      )
+
+      const [createdItem] = await transaction
+        .insert(equipmentItems)
+        .values({
+          brandId: body.brandId,
+          categoryId: body.categoryId,
+          createdBy: userId,
+          name: body.name,
+          status: 'pending'
+        })
+        .returning({
+          id: equipmentItems.id
+        })
+
+      if (createdItem === undefined) {
+        throw new Error('Equipment item insert returned no row')
+      }
+
+      if (normalizedProperties.length > 0) {
+        const propertyRows = normalizedProperties.map((property) => {
+          return {
+            itemId: createdItem.id,
+            propertyId: property.propertyId,
+            valueBoolean: property.valueBoolean,
+            valueNumber: property.valueNumber,
+            valueText: property.valueText
+          }
+        })
+
+        await transaction
+          .insert(itemPropertyValues)
+          .values(propertyRows)
+      }
+
+      await transaction
+        .insert(contributions)
+        .values({
+          action: 'submit_equipment_item',
+
+          metadata: {
+            brandId: brand.id,
+            brandName: brand.name,
+            categoryId: category.id,
+            categoryName: category.name,
+            name: body.name,
+            propertyCount: normalizedProperties.length,
+            status: 'pending'
+          },
+
+          targetId: createdItem.id,
+          userId
+        })
+
+      return {
+        id: createdItem.id,
+        status: 'pending' as const
+      }
+    })
+
+    setResponseStatus(event, 201)
+
+    return createdSubmission
+  } catch (error) {
+    const isExpectedClientError = isError(error)
+      && error.statusCode < 500
+
+    if (isExpectedClientError) {
+      throw error
+    }
+
+    console.error('Failed to submit equipment item', error)
+
+    throw createError({
+      status: 500,
+      message: 'Failed to submit equipment item'
+    })
+  } finally {
+    await dbWebsocket.$client.end()
+  }
+})
+
+export type { ItemSubmissionCreateResponse }

--- a/server/api/oauth/twitch/index.post.ts
+++ b/server/api/oauth/twitch/index.post.ts
@@ -5,7 +5,13 @@ import { updateAppSession } from '#server/utils/session'
 import { getTwitchOAuthToken, getTwitchUserInfo, getRuntimeTwitchConfig } from '#server/utils/oauth/twitch'
 import { validateTwitchOAuthBody } from '#server/utils/validation/schemas'
 
-export default defineEventHandler(async (event) => {
+interface TwitchOAuthResponse {
+  isAdmin: boolean;
+  isGuest: boolean;
+  userId: string;
+}
+
+export default defineEventHandler(async (event): Promise<TwitchOAuthResponse> => {
   const twitchConfig = getRuntimeTwitchConfig(event)
 
   const { code } = await readValidatedBody(event, validateTwitchOAuthBody)
@@ -32,7 +38,11 @@ export default defineEventHandler(async (event) => {
       userId: foundUser.userId
     })
 
-    return foundUser
+    return {
+      isAdmin: foundUser.isAdmin,
+      isGuest: foundUser.isGuest,
+      userId: foundUser.userId
+    }
   }
 
   // TODO (#104): Link the Twitch account to the current user

--- a/server/api/user/__tests__/index.test.ts
+++ b/server/api/user/__tests__/index.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import getUserHandler from '#server/api/user/index.get'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+const { getSessionUserMock } = vi.hoisted(() => {
+  return {
+    getSessionUserMock: vi.fn()
+  }
+})
+
+vi.mock(import('#server/utils/user'), () => {
+  return {
+    getSessionUser: getSessionUserMock
+  }
+})
+
+describe('get /api/user', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should return the stored account type', async () => {
+    getSessionUserMock.mockResolvedValue({
+      isAdmin: false,
+      isGuest: true,
+      userId: 'user-1'
+    })
+
+    const result = await getUserHandler(createTestEvent({}))
+
+    expect(result).toStrictEqual({
+      isAdmin: false,
+      isGuest: true,
+      userId: 'user-1'
+    })
+  })
+})

--- a/server/api/user/index.get.ts
+++ b/server/api/user/index.get.ts
@@ -1,6 +1,6 @@
 import { defineEventHandler } from 'h3'
-import { getSessionUser } from '#server/utils/user'
+import { getSessionUser, type SessionUser } from '#server/utils/user'
 
 export default defineEventHandler(
-  async (event) => getSessionUser(event)
+  async (event): Promise<SessionUser> => getSessionUser(event)
 )

--- a/server/database/__tests__/migration.test.ts
+++ b/server/database/__tests__/migration.test.ts
@@ -11,6 +11,11 @@ const imagesMigrationUrl = new URL(
   import.meta.url
 )
 const imagesMigrationSql = readFileSync(imagesMigrationUrl, 'utf8')
+const negativeValuesMigrationUrl = new URL(
+  '../migrations/20260808152209_stiff_ultragirl/migration.sql',
+  import.meta.url
+)
+const negativeValuesMigrationSql = readFileSync(negativeValuesMigrationUrl, 'utf8')
 
 describe('category property display order migration', () => {
   it('should backfill a zero-based order before making the column required', () => {
@@ -58,5 +63,22 @@ describe('equipment item image migration', () => {
     expect(imagesMigrationSql).toContain('"equipment_item_images_itemId_displayOrder_unique"')
     expect(imagesMigrationSql).toContain('"equipment_item_images_displayOrder_check"')
     expect(imagesMigrationSql).toContain('ON DELETE RESTRICT')
+  })
+})
+
+describe('category property negative value migration', () => {
+  it('should forbid negative values by default and preserve temperature ratings', () => {
+    const addColumnPosition = negativeValuesMigrationSql.indexOf(
+      'ADD COLUMN "allowsNegativeValues" boolean DEFAULT false NOT NULL'
+    )
+    const temperatureUpdatePosition = negativeValuesMigrationSql.indexOf(
+      'SET "allowsNegativeValues" = true'
+    )
+
+    expect(addColumnPosition).toBeGreaterThanOrEqual(0)
+    expect(temperatureUpdatePosition).toBeGreaterThan(addColumnPosition)
+    expect(negativeValuesMigrationSql).toContain('property."categoryId" = category.id')
+    expect(negativeValuesMigrationSql).toContain("category.slug = 'sleeping-bags'")
+    expect(negativeValuesMigrationSql).toContain("property.slug = 'temperature-rating'")
   })
 })

--- a/server/database/migrations/20260808152209_stiff_ultragirl/migration.sql
+++ b/server/database/migrations/20260808152209_stiff_ultragirl/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "category_properties" ADD COLUMN "allowsNegativeValues" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+UPDATE "category_properties" AS property
+SET "allowsNegativeValues" = true
+FROM "equipment_categories" AS category
+WHERE property."categoryId" = category.id
+  AND category.slug = 'sleeping-bags'
+  AND property.slug = 'temperature-rating'
+  AND property."dataType" = 'number';

--- a/server/database/migrations/20260808152209_stiff_ultragirl/snapshot.json
+++ b/server/database/migrations/20260808152209_stiff_ultragirl/snapshot.json
@@ -1,0 +1,1872 @@
+{
+  "version": "8",
+  "dialect": "postgres",
+  "id": "862f549b-9ad0-47a2-9724-e36623c9d8f4",
+  "prevIds": [
+    "836936ac-3ca6-4f54-8533-aefdcd9e2cb7"
+  ],
+  "ddl": [
+    {
+      "isRlsEnabled": false,
+      "name": "brands",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "category_properties",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "contributions",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "equipment_categories",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "equipment_groups",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "equipment_item_images",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "equipment_items",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "item_property_values",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_accounts",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "oauth_providers",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "packing_list_entries",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "packing_lists",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "property_enum_options",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "user_equipment",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "isRlsEnabled": false,
+      "name": "users",
+      "entityType": "tables",
+      "schema": "public"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "brands"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "brands"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "brands"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "brands"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "categoryId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "dataType",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "allowsNegativeValues",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "displayOrder",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "unit",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "action",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "targetId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "jsonb",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_categories"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_categories"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_categories"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_categories"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_groups"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_groups"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_groups"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_groups"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "itemId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "type": "text",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "cloudflareImageId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "displayOrder",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "categoryId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "brandId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "varchar(256)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "varchar(16)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "'approved'",
+      "generated": null,
+      "identity": null,
+      "name": "status",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "createdBy",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "itemId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "propertyId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valueText",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "numeric",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valueNumber",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "valueBoolean",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "providerId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "varchar",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "accountId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_providers"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "type",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_providers"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_providers"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "oauth_providers"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "packingListId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "customName",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userEquipmentId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "isPacked",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "updatedAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "type": "serial",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "type": "integer",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "propertyId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "type": "varchar(64)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "type": "varchar(128)",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "slug",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "userId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "itemId",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "type": "uuid",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "uuidv7()",
+      "generated": null,
+      "identity": null,
+      "name": "id",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "varchar(32)",
+      "typeSchema": null,
+      "notNull": false,
+      "dimensions": 0,
+      "default": null,
+      "generated": null,
+      "identity": null,
+      "name": "name",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "timestamp with time zone",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "now()",
+      "generated": null,
+      "identity": null,
+      "name": "createdAt",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "type": "boolean",
+      "typeSchema": null,
+      "notNull": true,
+      "dimensions": 0,
+      "default": "false",
+      "generated": null,
+      "identity": null,
+      "name": "isAdmin",
+      "entityType": "columns",
+      "schema": "public",
+      "table": "users"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "categoryId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "brandId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": "\"status\" = 'approved'",
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "equipment_items_approved_category_brand_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "propertyId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "valueNumber",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "itemId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "item_property_values_property_number_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "propertyId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "valueText",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "itemId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "item_property_values_property_text_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        {
+          "value": "propertyId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "valueBoolean",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        },
+        {
+          "value": "itemId",
+          "isExpression": false,
+          "asc": true,
+          "nullsFirst": false,
+          "opclass": null
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "with": "",
+      "method": "btree",
+      "concurrently": false,
+      "name": "item_property_values_property_boolean_index",
+      "entityType": "indexes",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "categoryId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_categories",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "category_properties_categoryId_equipment_categories_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "contributions_userId_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "contributions"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "itemId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_items",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "RESTRICT",
+      "name": "equipment_item_images_itemId_equipment_items_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "categoryId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_categories",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "RESTRICT",
+      "name": "equipment_items_categoryId_equipment_categories_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "brandId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "brands",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "RESTRICT",
+      "name": "equipment_items_brandId_brands_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "createdBy"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "SET NULL",
+      "name": "equipment_items_createdBy_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "equipment_items"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "itemId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_items",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "item_property_values_itemId_equipment_items_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "propertyId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "category_properties",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "item_property_values_propertyId_category_properties_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "oauth_accounts_userId_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "providerId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "oauth_providers",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "oauth_accounts_providerId_oauth_providers_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "packingListId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "packing_lists",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "packing_list_entries_packingListId_packing_lists_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userEquipmentId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "user_equipment",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "RESTRICT",
+      "name": "packing_list_entries_userEquipmentId_user_equipment_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "packing_lists_userId_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "packing_lists"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "propertyId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "category_properties",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "property_enum_options_propertyId_category_properties_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "users",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "user_equipment_userId_users_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "itemId"
+      ],
+      "schemaTo": "public",
+      "tableTo": "equipment_items",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "CASCADE",
+      "onDelete": "CASCADE",
+      "name": "user_equipment_itemId_equipment_items_id_fkey",
+      "entityType": "fks",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "brands_pkey",
+      "schema": "public",
+      "table": "brands",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "category_properties_pkey",
+      "schema": "public",
+      "table": "category_properties",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "contributions_pkey",
+      "schema": "public",
+      "table": "contributions",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "equipment_categories_pkey",
+      "schema": "public",
+      "table": "equipment_categories",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "equipment_groups_pkey",
+      "schema": "public",
+      "table": "equipment_groups",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "equipment_item_images_pkey",
+      "schema": "public",
+      "table": "equipment_item_images",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "equipment_items_pkey",
+      "schema": "public",
+      "table": "equipment_items",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "item_property_values_pkey",
+      "schema": "public",
+      "table": "item_property_values",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_accounts_pkey",
+      "schema": "public",
+      "table": "oauth_accounts",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "oauth_providers_pkey",
+      "schema": "public",
+      "table": "oauth_providers",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "packing_list_entries_pkey",
+      "schema": "public",
+      "table": "packing_list_entries",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "packing_lists_pkey",
+      "schema": "public",
+      "table": "packing_lists",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "property_enum_options_pkey",
+      "schema": "public",
+      "table": "property_enum_options",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "user_equipment_pkey",
+      "schema": "public",
+      "table": "user_equipment",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "users_pkey",
+      "schema": "public",
+      "table": "users",
+      "entityType": "pks"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "categoryId",
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "category_properties_categoryId_slug_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "categoryId",
+        "displayOrder"
+      ],
+      "nullsNotDistinct": false,
+      "name": "category_properties_categoryId_displayOrder_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "category_properties"
+    },
+    {
+      "nameExplicit": true,
+      "columns": [
+        "itemId",
+        "displayOrder"
+      ],
+      "nullsNotDistinct": false,
+      "name": "equipment_item_images_itemId_displayOrder_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "itemId",
+        "propertyId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "item_property_values_itemId_propertyId_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "item_property_values"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "providerId",
+        "accountId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_accounts_providerId_accountId_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "oauth_accounts"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "packingListId",
+        "userEquipmentId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "packing_list_entries_packingListId_userEquipmentId_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "packing_list_entries"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "propertyId",
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "property_enum_options_propertyId_slug_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "property_enum_options"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "userId",
+        "itemId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "user_equipment_userId_itemId_unique",
+      "entityType": "uniques",
+      "schema": "public",
+      "table": "user_equipment"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "name"
+      ],
+      "nullsNotDistinct": false,
+      "name": "brands_name_key",
+      "schema": "public",
+      "table": "brands",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "brands_slug_key",
+      "schema": "public",
+      "table": "brands",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "equipment_categories_slug_key",
+      "schema": "public",
+      "table": "equipment_categories",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "slug"
+      ],
+      "nullsNotDistinct": false,
+      "name": "equipment_groups_slug_key",
+      "schema": "public",
+      "table": "equipment_groups",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "cloudflareImageId"
+      ],
+      "nullsNotDistinct": false,
+      "name": "equipment_item_images_cloudflareImageId_key",
+      "schema": "public",
+      "table": "equipment_item_images",
+      "entityType": "uniques"
+    },
+    {
+      "nameExplicit": false,
+      "columns": [
+        "type"
+      ],
+      "nullsNotDistinct": false,
+      "name": "oauth_providers_type_key",
+      "schema": "public",
+      "table": "oauth_providers",
+      "entityType": "uniques"
+    },
+    {
+      "value": "\"displayOrder\" >= 0",
+      "name": "equipment_item_images_displayOrder_check",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "equipment_item_images"
+    },
+    {
+      "value": "((\"packing_list_entries\".\"customName\" IS NOT NULL) <> (\"packing_list_entries\".\"userEquipmentId\" IS NOT NULL))",
+      "name": "packing_list_entries_source_check",
+      "entityType": "checks",
+      "schema": "public",
+      "table": "packing_list_entries"
+    }
+  ],
+  "renames": []
+}

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -8,9 +8,9 @@ import { limits } from '../../shared/constants'
 // ─── Auth ───────────────────────────────────────────────────────────
 
 /**
- * Registered users.
+ * Guest and registered user accounts.
  *
- * Created automatically on first OAuth login.
+ * Created automatically on Guest or OAuth login.
  */
 const users = pgTable('users', {
   id:
@@ -338,6 +338,11 @@ const categoryProperties = pgTable('category_properties', {
   dataType:
     varchar({ length: 16 })
     .notNull(),
+
+  allowsNegativeValues:
+    boolean()
+    .notNull()
+    .default(false),
 
   displayOrder:
     integer()

--- a/server/utils/__tests__/user.test.ts
+++ b/server/utils/__tests__/user.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getSessionUser, validateRegisteredUser } from '#server/utils/user'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+const { clearAppSessionMock, useAppSessionMock } = vi.hoisted(() => {
+  return {
+    clearAppSessionMock: vi.fn(),
+    useAppSessionMock: vi.fn()
+  }
+})
+
+vi.mock(import('#server/utils/session'), () => {
+  return {
+    clearAppSession: clearAppSessionMock,
+    useAppSession: useAppSessionMock
+  }
+})
+
+function createUserDb(foundUser?: unknown) {
+  return {
+    query: {
+      users: {
+        findFirst: vi.fn(() => foundUser)
+      }
+    }
+  }
+}
+
+describe('user session helpers', () => {
+  beforeEach(() => {
+    useAppSessionMock.mockResolvedValue({
+      data: {
+        userId: 'user-1'
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should derive Guest status from the absence of OAuth accounts', async () => {
+    const db = createUserDb({
+      id: 'user-1',
+      isAdmin: false,
+      oauthAccounts: []
+    })
+
+    const result = await getSessionUser(createTestEvent(db))
+
+    expect(result).toStrictEqual({
+      isAdmin: false,
+      isGuest: true,
+      userId: 'user-1'
+    })
+    expect(db.query.users.findFirst).toHaveBeenCalledWith({
+      columns: {
+        id: true,
+        isAdmin: true
+      },
+
+      where: {
+        id: 'user-1'
+      },
+
+      with: {
+        oauthAccounts: {
+          columns: {
+            id: true
+          },
+
+          limit: 1
+        }
+      }
+    })
+  })
+
+  it('should return 401 without a valid session user', async () => {
+    useAppSessionMock.mockResolvedValue({ data: {} })
+
+    const result = validateRegisteredUser(createTestEvent(createUserDb()))
+
+    await expect(result).rejects.toMatchObject({ statusCode: 401 })
+  })
+
+  it('should return 401 when the session user no longer exists', async () => {
+    const event = createTestEvent(createUserDb())
+    const result = validateRegisteredUser(event)
+
+    await expect(result).rejects.toMatchObject({ statusCode: 401 })
+    expect(clearAppSessionMock).toHaveBeenCalledWith(event)
+  })
+
+  it('should return 403 for a Guest account', async () => {
+    const db = createUserDb({
+      id: 'user-1',
+      isAdmin: false,
+      oauthAccounts: []
+    })
+
+    const result = validateRegisteredUser(createTestEvent(db))
+
+    await expect(result).rejects.toMatchObject({ statusCode: 403 })
+  })
+
+  it('should return the registered user id', async () => {
+    const db = createUserDb({
+      id: 'user-1',
+      isAdmin: false,
+      oauthAccounts: [{ id: 'oauth-account-1' }]
+    })
+
+    const result = await validateRegisteredUser(createTestEvent(db))
+
+    expect(result).toBe('user-1')
+  })
+})

--- a/server/utils/equipment/__tests__/item-submission-properties.test.ts
+++ b/server/utils/equipment/__tests__/item-submission-properties.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeItemSubmissionProperties } from '../item-submission-properties'
+
+const definitions = [{
+  allowsNegativeValues: false,
+  categoryId: 2,
+  dataType: 'text',
+  enumOptions: [],
+  id: 1
+}, {
+  allowsNegativeValues: false,
+  categoryId: 2,
+  dataType: 'number',
+  enumOptions: [],
+  id: 2
+}, {
+  allowsNegativeValues: false,
+  categoryId: 2,
+  dataType: 'boolean',
+  enumOptions: [],
+  id: 3
+}, {
+  allowsNegativeValues: false,
+  categoryId: 2,
+  dataType: 'enum',
+  enumOptions: [{ slug: 'canister' }, { slug: 'alcohol' }],
+  id: 4
+}]
+
+describe('item submission properties', () => {
+  it('should map every supported value to the correct EAV column', () => {
+    const result = normalizeItemSubmissionProperties(2, definitions, [{
+      propertyId: 1,
+      value: '  Three season  '
+    }, {
+      propertyId: 2,
+      value: '+0083.500'
+    }, {
+      propertyId: 3,
+      value: false
+    }, {
+      propertyId: 4,
+      value: 'canister'
+    }])
+
+    expect(result).toStrictEqual([{
+      propertyId: 1,
+      valueBoolean: null,
+      valueNumber: null,
+      valueText: 'Three season'
+    }, {
+      propertyId: 2,
+      valueBoolean: null,
+      valueNumber: '83.5',
+      valueText: null
+    }, {
+      propertyId: 3,
+      valueBoolean: false,
+      valueNumber: null,
+      valueText: null
+    }, {
+      propertyId: 4,
+      valueBoolean: null,
+      valueNumber: null,
+      valueText: 'canister'
+    }])
+  })
+
+  it.each([
+    {
+      definitions,
+      inputs: [{ propertyId: 99, value: 'unknown' }],
+      name: 'unknown property'
+    },
+    {
+      definitions: [{ allowsNegativeValues: false, categoryId: 3, dataType: 'text', enumOptions: [], id: 1 }],
+      inputs: [{ propertyId: 1, value: 'wrong category' }],
+      name: 'property from another category'
+    },
+    {
+      definitions,
+      inputs: [{ propertyId: 1, value: '   ' }],
+      name: 'empty text'
+    },
+    {
+      definitions,
+      inputs: [{ propertyId: 2, value: 'Infinity' }],
+      name: 'invalid number'
+    },
+    {
+      definitions,
+      inputs: [{ propertyId: 2, value: '-0.1' }],
+      name: 'negative number without permission'
+    },
+    {
+      definitions,
+      inputs: [{ propertyId: 2, value: true }],
+      name: 'wrong number type'
+    },
+    {
+      definitions,
+      inputs: [{ propertyId: 3, value: 'false' }],
+      name: 'wrong boolean type'
+    },
+    {
+      definitions,
+      inputs: [{ propertyId: 4, value: 'liquid' }],
+      name: 'unknown enum option'
+    }
+  ])('should reject $name', ({ definitions: propertyDefinitions, inputs }) => {
+    expect(() => normalizeItemSubmissionProperties(2, propertyDefinitions, inputs)).toThrow(
+      expect.objectContaining({ statusCode: 400 })
+    )
+  })
+
+  it('should allow negative values for properties that explicitly support them', () => {
+    const temperatureDefinition = [{
+      allowsNegativeValues: true,
+      categoryId: 2,
+      dataType: 'number',
+      enumOptions: [],
+      id: 5
+    }]
+
+    const result = normalizeItemSubmissionProperties(2, temperatureDefinition, [{
+      propertyId: 5,
+      value: '-10.5'
+    }])
+
+    expect(result).toStrictEqual([{
+      propertyId: 5,
+      valueBoolean: null,
+      valueNumber: '-10.5',
+      valueText: null
+    }])
+  })
+
+  it('should treat an unsupported stored data type as a server error', () => {
+    const unsupportedDefinitions = [{
+      allowsNegativeValues: false,
+      categoryId: 2,
+      dataType: 'decimal',
+      enumOptions: [],
+      id: 1
+    }]
+
+    expect(() => normalizeItemSubmissionProperties(2, unsupportedDefinitions, [{
+      propertyId: 1,
+      value: '12'
+    }])).toThrow(expect.objectContaining({ statusCode: 500 }))
+  })
+})

--- a/server/utils/equipment/item-submission-properties.ts
+++ b/server/utils/equipment/item-submission-properties.ts
@@ -1,0 +1,156 @@
+import { createError } from 'h3'
+import { isFiniteDecimalNumber, normalizeDecimalNumber } from '#shared/utils/decimal-number'
+
+interface ItemSubmissionPropertyInput {
+  propertyId: number;
+  value: boolean | string;
+}
+
+interface ItemSubmissionEnumOptionDefinition {
+  slug: string;
+}
+
+interface ItemSubmissionPropertyDefinition {
+  allowsNegativeValues: boolean;
+  categoryId: number;
+  dataType: string;
+  enumOptions: ItemSubmissionEnumOptionDefinition[];
+  id: number;
+}
+
+interface ItemSubmissionPropertyValue {
+  propertyId: number;
+  valueBoolean: boolean | null;
+  valueNumber: string | null;
+  valueText: string | null;
+}
+
+function createInvalidPropertyError(message: string) {
+  return createError({
+    status: 400,
+    message
+  })
+}
+
+function normalizeTextValue(value: boolean | string) {
+  if (typeof value !== 'string') {
+    throw createInvalidPropertyError('Text property value must be a string')
+  }
+
+  const normalizedValue = value.trim()
+
+  if (normalizedValue === '') {
+    throw createInvalidPropertyError('Text property value must not be empty')
+  }
+
+  return normalizedValue
+}
+
+function normalizeNumberValue(value: boolean | string, allowsNegativeValues: boolean) {
+  if (typeof value !== 'string') {
+    throw createInvalidPropertyError('Number property value must be a string')
+  }
+
+  const trimmedValue = value.trim()
+  const hasValidNumber = isFiniteDecimalNumber(trimmedValue)
+
+  if (hasValidNumber === false) {
+    throw createInvalidPropertyError('Number property value must be a finite decimal')
+  }
+
+  const normalizedValue = normalizeDecimalNumber(trimmedValue)
+  const isNegativeValue = normalizedValue.startsWith('-')
+
+  if (isNegativeValue && allowsNegativeValues === false) {
+    throw createInvalidPropertyError('Number property value must not be negative')
+  }
+
+  return normalizedValue
+}
+
+function normalizeBooleanValue(value: boolean | string) {
+  if (typeof value !== 'boolean') {
+    throw createInvalidPropertyError('Boolean property value must be a boolean')
+  }
+
+  return value
+}
+
+function normalizeEnumValue(
+  value: boolean | string,
+  options: ItemSubmissionEnumOptionDefinition[]
+) {
+  if (typeof value !== 'string') {
+    throw createInvalidPropertyError('Enum property value must be a string')
+  }
+
+  const normalizedValue = value.trim()
+  const hasMatchingOption = options.some((option) => option.slug === normalizedValue)
+
+  if (hasMatchingOption === false) {
+    throw createInvalidPropertyError('Enum property value must match an available option')
+  }
+
+  return normalizedValue
+}
+
+/** Validates submitted category properties and maps them to the EAV value columns. */
+function normalizeItemSubmissionProperties(
+  categoryId: number,
+  definitions: ItemSubmissionPropertyDefinition[],
+  inputs: ItemSubmissionPropertyInput[]
+): ItemSubmissionPropertyValue[] {
+  const definitionsById = new Map(definitions.map((definition) => [definition.id, definition]))
+
+  return inputs.map((input) => {
+    const definition = definitionsById.get(input.propertyId)
+
+    if (definition === undefined || definition.categoryId !== categoryId) {
+      throw createInvalidPropertyError('Property does not belong to the selected category')
+    }
+
+    const valueColumns: ItemSubmissionPropertyValue = {
+      propertyId: input.propertyId,
+      valueBoolean: null,
+      valueNumber: null,
+      valueText: null
+    }
+
+    if (definition.dataType === 'text') {
+      valueColumns.valueText = normalizeTextValue(input.value)
+
+      return valueColumns
+    }
+
+    if (definition.dataType === 'number') {
+      valueColumns.valueNumber = normalizeNumberValue(input.value, definition.allowsNegativeValues)
+
+      return valueColumns
+    }
+
+    if (definition.dataType === 'boolean') {
+      valueColumns.valueBoolean = normalizeBooleanValue(input.value)
+
+      return valueColumns
+    }
+
+    if (definition.dataType === 'enum') {
+      valueColumns.valueText = normalizeEnumValue(input.value, definition.enumOptions)
+
+      return valueColumns
+    }
+
+    throw createError({
+      status: 500,
+      message: `Unsupported equipment property data type: ${definition.dataType}`
+    })
+  })
+}
+
+export { normalizeItemSubmissionProperties }
+
+export type {
+  ItemSubmissionPropertyDefinition,
+  ItemSubmissionPropertyInput,
+  ItemSubmissionPropertyValue
+}

--- a/server/utils/oauth/__tests__/account.test.ts
+++ b/server/utils/oauth/__tests__/account.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { oauthAccounts, users } from '#server/database/schema'
+import { createOAuthUser } from '#server/utils/oauth/account'
+import { createTestEvent } from '~~/test-utils/create-test-event'
+
+const { createWebSocketClientMock } = vi.hoisted(() => {
+  return {
+    createWebSocketClientMock: vi.fn()
+  }
+})
+
+vi.mock(import('#server/utils/config'), () => {
+  return {
+    createWebSocketClientFromEvent: createWebSocketClientMock
+  }
+})
+
+describe(createOAuthUser, () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should create and return an explicit registered account', async () => {
+    const userReturningMock = vi.fn(() => [{
+      isAdmin: false,
+      userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477bb'
+    }])
+    const userValuesMock = vi.fn(() => {
+      return { returning: userReturningMock }
+    })
+    const accountValuesMock = vi.fn()
+    const insertMock = vi.fn()
+      .mockReturnValueOnce({ values: userValuesMock })
+      .mockReturnValueOnce({ values: accountValuesMock })
+    const transaction = {
+      insert: insertMock,
+
+      query: {
+        oauthProviders: {
+          findFirst: vi.fn(() => {
+            return { id: 7 }
+          })
+        }
+      }
+    }
+    const dbWebsocket = {
+      $client: {
+        end: vi.fn()
+      },
+
+      transaction: vi.fn(
+        async (execute: (value: typeof transaction) => Promise<unknown>) => execute(transaction)
+      )
+    }
+
+    createWebSocketClientMock.mockReturnValue(dbWebsocket)
+
+    const result = await createOAuthUser(
+      'twitch',
+      'twitch-account-1',
+      createTestEvent({})
+    )
+
+    expect(userValuesMock).toHaveBeenCalledWith({})
+    expect(insertMock).toHaveBeenNthCalledWith(1, users)
+    expect(insertMock).toHaveBeenNthCalledWith(2, oauthAccounts)
+    expect(accountValuesMock).toHaveBeenCalledWith({
+      accountId: 'twitch-account-1',
+      providerId: 7,
+      userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477bb'
+    })
+    expect(result).toStrictEqual({
+      isAdmin: false,
+      isGuest: false,
+      userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477bb'
+    })
+    expect(dbWebsocket.$client.end).toHaveBeenCalledTimes(1)
+  })
+})

--- a/server/utils/oauth/account.ts
+++ b/server/utils/oauth/account.ts
@@ -6,6 +6,7 @@ import { oauthAccounts, users } from '#server/database/schema'
 interface OAuthUserResult {
   readonly userId: string;
   readonly isAdmin: boolean;
+  readonly isGuest: boolean;
 }
 
 async function createOAuthUser(
@@ -62,13 +63,15 @@ async function createOAuthUser(
 
         return {
           userId: foundUser.userId,
-          isAdmin: foundUser.isAdmin
+          isAdmin: foundUser.isAdmin,
+          isGuest: false
         }
       })
 
       return {
         userId: newUser.userId,
-        isAdmin: newUser.isAdmin
+        isAdmin: newUser.isAdmin,
+        isGuest: newUser.isGuest
       }
     } finally {
       await dbWebsocket.$client.end()

--- a/server/utils/user.ts
+++ b/server/utils/user.ts
@@ -1,20 +1,22 @@
-import type { H3Event } from 'h3'
+import { createError, type H3Event } from 'h3'
 import { and, eq } from 'drizzle-orm'
 import type { OAuthProvider } from '#shared/types/oauth'
 import { clearAppSession, useAppSession } from '#server/utils/session'
 import { oauthAccounts, oauthProviders, users } from '#server/database/schema'
 
-interface ReturnUser {
+interface SessionUser {
   readonly userId: string | null;
   readonly isAdmin: boolean;
+  readonly isGuest: boolean;
 }
 
-const defaultUser : ReturnUser = {
+const defaultUser : SessionUser = {
   userId: null,
-  isAdmin: false
+  isAdmin: false,
+  isGuest: false
 }
 
-async function getSessionUser(event: H3Event) : Promise<ReturnUser> {
+async function getSessionUser(event: H3Event) : Promise<SessionUser> {
   const session = await useAppSession(event)
   const { userId } = session.data
 
@@ -32,6 +34,16 @@ async function getSessionUser(event: H3Event) : Promise<ReturnUser> {
 
       where: {
         id: userId
+      },
+
+      with: {
+        oauthAccounts: {
+          columns: {
+            id: true
+          },
+
+          limit: 1
+        }
       }
     })
 
@@ -41,9 +53,12 @@ async function getSessionUser(event: H3Event) : Promise<ReturnUser> {
     return defaultUser
   }
 
+  const isGuest = foundUser.oauthAccounts.length === 0
+
   return {
     userId: foundUser.id,
-    isAdmin: foundUser.isAdmin
+    isAdmin: foundUser.isAdmin,
+    isGuest
   }
 }
 
@@ -51,7 +66,7 @@ async function getUserByOAuthAccount(
   provider: OAuthProvider,
   accountId: string,
   event: H3Event
-) : Promise<ReturnUser> {
+) : Promise<SessionUser> {
   const [foundUser] = await event.context.dbHttp
     .select({
       userId: oauthAccounts.userId,
@@ -74,7 +89,30 @@ async function getUserByOAuthAccount(
       eq(oauthAccounts.accountId, accountId)
     )
 
-  return foundUser ?? defaultUser
+  if (foundUser === undefined) {
+    return defaultUser
+  }
+
+  return {
+    userId: foundUser.userId,
+    isAdmin: foundUser.isAdmin,
+    isGuest: false
+  }
 }
 
-export { getSessionUser, getUserByOAuthAccount }
+async function validateRegisteredUser(event: H3Event): Promise<string> {
+  const user = await getSessionUser(event)
+
+  if (user.userId === null) {
+    throw createError({ status: 401 })
+  }
+
+  if (user.isGuest) {
+    throw createError({ status: 403 })
+  }
+
+  return user.userId
+}
+
+export { getSessionUser, getUserByOAuthAccount, validateRegisteredUser }
+export type { SessionUser }

--- a/server/utils/validation/__tests__/schemas.test.ts
+++ b/server/utils/validation/__tests__/schemas.test.ts
@@ -16,6 +16,7 @@ import {
   validateGroupMutationBody,
   validateItemDetailParams,
   validateItemImageUploadQuery,
+  validateItemSubmissionCreateBody,
   validateEquipmentComparisonQuery,
   validateItemsListQuery,
   validatePackingListAvailableGearQuery,
@@ -1169,6 +1170,72 @@ describe('validation schemas', () => {
     expect(() => validateUserEquipmentCreateBody({
       itemId: '550e8400-e29b-41d4-a716-446655440000'
     })).toThrow(/./u)
+  })
+
+  it('should trim an item submission name and default properties to an empty array', () => {
+    const result = validateItemSubmissionCreateBody({
+      brandId: 1,
+      categoryId: 2,
+      name: '  PocketRocket Deluxe  '
+    })
+
+    expect(result).toStrictEqual({
+      brandId: 1,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+      properties: []
+    })
+  })
+
+  it('should accept string and boolean item submission property values', () => {
+    const result = validateItemSubmissionCreateBody({
+      brandId: 1,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+
+      properties: [{
+        propertyId: 3,
+        value: '83.5'
+      }, {
+        propertyId: 4,
+        value: false
+      }]
+    })
+
+    expect(result.properties).toStrictEqual([{
+      propertyId: 3,
+      value: '83.5'
+    }, {
+      propertyId: 4,
+      value: false
+    }])
+  })
+
+  it.each([
+    { brandId: 0, categoryId: 2, name: 'Item', properties: [] },
+    { brandId: 1.5, categoryId: 2, name: 'Item', properties: [] },
+    { brandId: 1, categoryId: -1, name: 'Item', properties: [] },
+    { brandId: 1, categoryId: 2, name: '   ', properties: [] },
+    {
+      brandId: 1,
+      categoryId: 2,
+      name: 'I'.repeat(limits.maxEquipmentItemNameLength + 1),
+      properties: []
+    },
+    {
+      brandId: 1,
+      categoryId: 2,
+      name: 'Item',
+      properties: [{ propertyId: 1, value: 12 }]
+    },
+    {
+      brandId: 1,
+      categoryId: 2,
+      name: 'Item',
+      properties: [{ propertyId: 1, value: 'one' }, { propertyId: 1, value: 'two' }]
+    }
+  ])('should reject invalid item submission body: %j', (body) => {
+    expect(() => validateItemSubmissionCreateBody(body)).toThrow(/./u)
   })
 
   it('should trim an equipment image upload filename', () => {

--- a/server/utils/validation/schemas.ts
+++ b/server/utils/validation/schemas.ts
@@ -201,6 +201,49 @@ const itemDetailParamsSchema = v.object({
   id: canonicalUuidV7Schema
 })
 
+const itemSubmissionPropertyValueSchema = v.union([
+  v.boolean(),
+  v.string()
+])
+
+const itemSubmissionPropertySchema = v.object({
+  propertyId: v.pipe(
+    v.number(),
+    v.integer(),
+    v.minValue(1)
+  ),
+
+  value: itemSubmissionPropertyValueSchema
+})
+
+const itemSubmissionCreateBodySchema = v.pipe(
+  v.object({
+    brandId: v.pipe(
+      v.number(),
+      v.integer(),
+      v.minValue(1)
+    ),
+
+    categoryId: v.pipe(
+      v.number(),
+      v.integer(),
+      v.minValue(1)
+    ),
+
+    name: v.pipe(
+      trimmedNonEmptyStringSchema,
+      v.maxLength(limits.maxEquipmentItemNameLength)
+    ),
+
+    properties: v.optional(v.array(itemSubmissionPropertySchema), [])
+  }),
+  v.check((input) => {
+    const propertyIds = input.properties.map((property) => property.propertyId)
+
+    return new Set(propertyIds).size === propertyIds.length
+  }, 'properties must contain unique propertyId values')
+)
+
 const itemImageParamsSchema = v.object({
   id: canonicalUuidV7Schema,
   'image-id': canonicalUuidV7Schema
@@ -659,6 +702,10 @@ function validateItemDetailParams(params: unknown) {
   return v.parse(itemDetailParamsSchema, params)
 }
 
+function validateItemSubmissionCreateBody(body: unknown) {
+  return v.parse(itemSubmissionCreateBodySchema, body)
+}
+
 function validateItemImageParams(params: unknown) {
   return v.parse(itemImageParamsSchema, params)
 }
@@ -743,6 +790,7 @@ export {
   groupIdParamsSchema,
   groupMutationSchema,
   itemDetailParamsSchema,
+  itemSubmissionCreateBodySchema,
   itemImageOrderBodySchema,
   itemImageParamsSchema,
   itemImageUploadQuerySchema,
@@ -780,6 +828,7 @@ export {
   validateGroupIdParams,
   validateGroupMutationBody,
   validateItemDetailParams,
+  validateItemSubmissionCreateBody,
   validateItemImageOrderBody,
   validateItemImageParams,
   validateItemImageUploadQuery,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -11,6 +11,7 @@ const limits = {
   maxEquipmentGroupNameLength: 64,
   maxEquipmentGroupSlugLength: 128,
   maxEquipmentItemImageFilenameLength: 255,
+  maxEquipmentItemNameLength: 256,
   maxEquipmentItemsFilterCount: 20,
   maxPackingListEntryCustomNameLength: 128,
   maxPackingListNameLength: 128,

--- a/tests/playwright/dashboard/dashboard.test.ts
+++ b/tests/playwright/dashboard/dashboard.test.ts
@@ -7,6 +7,7 @@ test.describe('Dashboard page', () => {
         status: 201,
 
         json: {
+          isGuest: true,
           userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
         }
       })

--- a/tests/playwright/dashboard/sidebar-collapsed.test.ts
+++ b/tests/playwright/dashboard/sidebar-collapsed.test.ts
@@ -7,6 +7,7 @@ async function mockGuestLogin(context: BrowserContext) {
       status: 201,
 
       json: {
+        isGuest: true,
         userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
       }
     })

--- a/tests/playwright/fixtures/gear-library-entry-list.fixtures.ts
+++ b/tests/playwright/fixtures/gear-library-entry-list.fixtures.ts
@@ -739,6 +739,7 @@ async function mockGuestLogin(context: BrowserContext): Promise<void> {
       status: 201,
 
       json: {
+        isGuest: true,
         userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
       }
     })

--- a/tests/playwright/gear-library/equipment-image-management.test.ts
+++ b/tests/playwright/gear-library/equipment-image-management.test.ts
@@ -87,6 +87,7 @@ test.describe('Equipment image management', () => {
       await route.fulfill({
         json: {
           isAdmin: true,
+          isGuest: false,
           userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
         }
       })
@@ -133,6 +134,7 @@ test.describe('Equipment image management', () => {
       await route.fulfill({
         json: {
           isAdmin: true,
+          isGuest: false,
           userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
         }
       })
@@ -206,6 +208,7 @@ test.describe('Equipment image management', () => {
       await route.fulfill({
         json: {
           isAdmin: true,
+          isGuest: false,
           userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
         }
       })

--- a/tests/playwright/gear-library/gear-library-item-detail.test.ts
+++ b/tests/playwright/gear-library/gear-library-item-detail.test.ts
@@ -34,6 +34,7 @@ test.describe('Gear library item detail', () => {
       await route.fulfill({
         status: 201,
         json: {
+          isGuest: true,
           userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
         }
       })
@@ -100,6 +101,7 @@ test.describe('Gear library item detail', () => {
       await route.fulfill({
         json: {
           isAdmin: true,
+          isGuest: false,
           userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
         }
       })

--- a/tests/playwright/gear-library/gear-submissions.test.ts
+++ b/tests/playwright/gear-library/gear-submissions.test.ts
@@ -1,0 +1,514 @@
+import type { BrowserContext, Page, Request, Route } from '@playwright/test'
+import { expect, test } from '../fixtures/global.fixtures.ts'
+import {
+  createDeferred,
+  mockCatalogApi,
+  mockGuestLogin,
+  openGearLibrary,
+  selectPerdOption
+} from '../fixtures/gear-library-entry-list.fixtures.ts'
+
+const pendingItemId = '0195f6e8-8f44-74f6-bc9a-5c8f7df477ee'
+
+const brands = [{
+  id: 10,
+  name: 'MSR',
+  slug: 'msr'
+}]
+
+const categories = [{
+  id: 2,
+  name: 'Stoves',
+  slug: 'stoves'
+}, {
+  id: 1,
+  name: 'Sleeping Pads',
+  slug: 'sleeping-pads'
+}]
+
+const stovesCategory = {
+  id: 2,
+  name: 'Stoves',
+  slug: 'stoves',
+
+  properties: [{
+    dataType: 'number',
+    id: 21,
+    name: 'Weight',
+    slug: 'weight',
+    unit: 'g'
+  }, {
+    dataType: 'text',
+    id: 24,
+    name: 'Notes',
+    slug: 'notes',
+    unit: null
+  }, {
+    dataType: 'text',
+    id: 25,
+    name: 'Manufacturer code',
+    slug: 'manufacturer-code',
+    unit: null
+  }, {
+    dataType: 'enum',
+
+    enumOptions: [{
+      id: 31,
+      name: 'Canister',
+      slug: 'canister'
+    }],
+
+    id: 23,
+    name: 'Fuel type',
+    slug: 'fuel-type',
+    unit: null
+  }, {
+    dataType: 'boolean',
+    id: 22,
+    name: 'Piezo ignition',
+    slug: 'piezo-ignition',
+    unit: null
+  }]
+} as const
+
+const sleepingPadsCategory = {
+  id: 1,
+  name: 'Sleeping Pads',
+  slug: 'sleeping-pads',
+
+  properties: [{
+    dataType: 'number',
+    id: 11,
+    name: 'R-value',
+    slug: 'r-value',
+    unit: null
+  }]
+} as const
+
+interface SubmissionReferenceMockOptions {
+  categoryDetail?: (route: Route) => Promise<void>;
+  submit?: (route: Route) => Promise<void>;
+}
+
+async function mockSubmissionApi(
+  context: BrowserContext,
+  options: SubmissionReferenceMockOptions = {}
+) {
+  await context.route((url) => url.pathname === '/api/equipment/brands', async (route) => {
+    await route.fulfill({ json: brands })
+  })
+
+  await context.route((url) => url.pathname === '/api/equipment/categories', async (route) => {
+    await route.fulfill({ json: categories })
+  })
+
+  await context.route((url) => url.pathname.startsWith('/api/equipment/categories/by-slug/'), async (route) => {
+    if (options.categoryDetail !== undefined) {
+      await options.categoryDetail(route)
+
+      return
+    }
+
+    const request = route.request()
+    const { pathname } = new globalThis.URL(request.url())
+    const response = pathname.endsWith('/sleeping-pads') ? sleepingPadsCategory : stovesCategory
+
+    await route.fulfill({ json: response })
+  })
+
+  await context.route((url) => url.pathname === '/api/equipment/item-submissions', async (route) => {
+    if (options.submit !== undefined) {
+      await options.submit(route)
+
+      return
+    }
+
+    await route.fulfill({
+      status: 201,
+      json: { id: pendingItemId, status: 'pending' }
+    })
+  })
+}
+
+async function openRegisteredSubmissionPage(context: BrowserContext, page: Page) {
+  await context.route((url) => url.pathname === '/api/oauth/twitch', async (route) => {
+    await route.fulfill({
+      json: {
+        isAdmin: false,
+        isGuest: false,
+        userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
+      }
+    })
+  })
+
+  await page.goto('/auth/twitch?code=twitch-code&state=/gear-library/new')
+  await expect(page).toHaveURL(/\/gear-library\/new$/u)
+}
+
+function getSelect(page: Page, label: 'Brand' | 'Category' | 'Fuel type' | 'Piezo ignition') {
+  return page.getByRole('combobox', { name: new RegExp(`^${label}`, 'u') })
+}
+
+async function fillBaseFields(page: Page) {
+  await page.getByLabel('Item name').fill('PocketRocket Deluxe')
+  await selectPerdOption(getSelect(page, 'Brand'), '10')
+  await selectPerdOption(getSelect(page, 'Category'), 'stoves')
+}
+
+function isSubmissionRequest(request: Request) {
+  const requestUrl = new globalThis.URL(request.url())
+
+  return requestUrl.pathname === '/api/equipment/item-submissions' && request.method() === 'POST'
+}
+
+function isBrandsRequest(request: Request) {
+  const requestUrl = new globalThis.URL(request.url())
+
+  return requestUrl.pathname === '/api/equipment/brands' && request.method() === 'GET'
+}
+
+function trackSubmissionPageRequests(page: Page) {
+  const submissionPagePaths = new Set([
+    '/api/equipment/brands',
+    '/api/equipment/categories',
+    '/api/equipment/item-submissions'
+  ])
+  let requestCount = 0
+
+  page.on('request', (request) => {
+    const { pathname } = new globalThis.URL(request.url())
+
+    requestCount += Number(submissionPagePaths.has(pathname))
+  })
+
+  return () => requestCount
+}
+
+function trackMyGearPosts(page: Page) {
+  let requestCount = 0
+
+  page.on('request', (request) => {
+    const requestUrl = new globalThis.URL(request.url())
+    const isMyGearPost = requestUrl.pathname === '/api/user/gear' && request.method() === 'POST'
+
+    if (isMyGearPost) {
+      requestCount += 1
+    }
+  })
+
+  return () => requestCount
+}
+
+function createRetryingSubmitResponder() {
+  let requestCount = 0
+
+  return {
+    getRequestCount: () => requestCount,
+
+    respond: async (route: Route) => {
+      requestCount += 1
+
+      if (requestCount === 1) {
+        await route.fulfill({ status: 500, json: { statusCode: 500 } })
+
+        return
+      }
+
+      await route.fulfill({
+        status: 201,
+        json: { id: pendingItemId, status: 'pending' }
+      })
+    }
+  }
+}
+
+function createRecoveringBrandsResponder() {
+  let requestCount = 0
+  let shouldSucceed = false
+
+  return {
+    allowSuccess: () => {
+      shouldSucceed = true
+    },
+
+    getRequestCount: () => requestCount,
+
+    respond: async (route: Route) => {
+      requestCount += 1
+
+      if (shouldSucceed) {
+        await route.fulfill({ json: brands })
+
+        return
+      }
+
+      await route.fulfill({ status: 500, json: { statusCode: 500 } })
+    }
+  }
+}
+
+function createStaleCategoryResponder(staleRouteGate: Promise<void>) {
+  return async (route: Route) => {
+    const request = route.request()
+    const { pathname } = new globalThis.URL(request.url())
+
+    if (pathname.endsWith('/stoves')) {
+      await staleRouteGate
+
+      return
+    }
+
+    await route.fulfill({ json: sleepingPadsCategory })
+  }
+}
+
+test.describe('Gear submissions', () => {
+  test('should redirect an unauthenticated user to login with the submission return target', async ({ page }) => {
+    await page.goto('/gear-library/new')
+
+    const currentUrl = new globalThis.URL(page.url())
+
+    expect(currentUrl.pathname).toBe('/login')
+    expect(currentUrl.searchParams.get('redirectTo')).toBe('/gear-library/new')
+  })
+
+  test('should open the protected submission page from the Gear library CTA', async ({ context, page }) => {
+    await mockGuestLogin(context)
+    await mockCatalogApi(context)
+    await openGearLibrary(page)
+    const submitGearLink = page.getByRole('link', { name: 'Submit gear' })
+
+    await expect(submitGearLink).toBeVisible()
+    await submitGearLink.click()
+
+    await expect(page).toHaveURL(/\/gear-library\/new$/u)
+    await expect(page.getByRole('heading', { name: 'Submit missing gear' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Account required.' })).toBeVisible()
+    await expect(page.getByText(
+      'Guest accounts cannot submit gear for review. Account upgrade options will be available later.'
+    )).toBeVisible()
+    await expect(page.getByRole('link', { name: 'Back to Gear library' })).toBeVisible()
+    await expect(page.locator('form')).toHaveCount(0)
+  })
+
+  test('should not load submission data or submit for a Guest', async ({ context, page }) => {
+    const getSubmissionPageRequestCount = trackSubmissionPageRequests(page)
+
+    await mockGuestLogin(context)
+    await page.goto('/login?redirectTo=/gear-library/new')
+    await page.getByRole('button', { name: 'Guest' }).click()
+
+    await expect(page).toHaveURL(/\/gear-library\/new$/u)
+    await expect(page.getByRole('heading', { name: 'Account required.' })).toBeVisible()
+    await expect(page.locator('form')).toHaveCount(0)
+    expect(getSubmissionPageRequestCount()).toBe(0)
+  })
+
+  test('should recover mandatory references after retry', async ({ context, page }) => {
+    const brandsResponder = createRecoveringBrandsResponder()
+
+    await mockSubmissionApi(context)
+    await context.route(
+      (url) => url.pathname === '/api/equipment/brands',
+      brandsResponder.respond
+    )
+    await openRegisteredSubmissionPage(context, page)
+    const brandSelect = getSelect(page, 'Brand')
+    const categorySelect = getSelect(page, 'Category')
+
+    await expect(page.getByText('Could not load brands and categories.')).toBeVisible()
+    await expect(brandSelect).toBeDisabled()
+    await expect(categorySelect).toBeDisabled()
+    const requestCountBeforeRetry = brandsResponder.getRequestCount()
+    const brandRetryRequestPromise = page.waitForRequest(isBrandsRequest)
+
+    brandsResponder.allowSuccess()
+    await page.getByRole('button', { name: 'Retry' }).click()
+    await brandRetryRequestPromise
+    await expect(brandSelect).toBeEnabled()
+    await expect(categorySelect).toBeEnabled()
+    expect(brandsResponder.getRequestCount()).toBeGreaterThan(requestCountBeforeRetry)
+
+    await fillBaseFields(page)
+    await expect(page.getByRole('button', { name: 'Submit for review' })).toBeEnabled()
+  })
+
+  test('should submit exact typed properties and replace the form with confirmation', async ({
+    context,
+    page
+  }) => {
+    const getMyGearPostCount = trackMyGearPosts(page)
+    await mockSubmissionApi(context)
+    await openRegisteredSubmissionPage(context, page)
+    await expect(page.getByLabel('Item name')).toHaveAttribute('required', '')
+    await expect(getSelect(page, 'Brand')).toHaveAttribute('aria-required', 'true')
+    await expect(getSelect(page, 'Category')).toHaveAttribute('aria-required', 'true')
+    await fillBaseFields(page)
+    await page.getByLabel('Weight').fill('83.5')
+    await page.getByLabel('Notes').fill('  Three season  ')
+    await selectPerdOption(getSelect(page, 'Fuel type'), 'canister')
+    const booleanSelect = getSelect(page, 'Piezo ignition')
+
+    await expect(booleanSelect).toHaveAttribute('data-value', '')
+    await selectPerdOption(booleanSelect, 'false')
+
+    const submissionRequestPromise = page.waitForRequest(isSubmissionRequest)
+
+    await page.getByRole('button', { name: 'Submit for review' }).click()
+
+    const submissionRequest = await submissionRequestPromise
+    const requestBody: unknown = submissionRequest.postDataJSON()
+
+    expect(requestBody).toStrictEqual({
+      brandId: 10,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+
+      properties: [{
+        propertyId: 21,
+        value: '83.5'
+      }, {
+        propertyId: 24,
+        value: 'Three season'
+      }, {
+        propertyId: 23,
+        value: 'canister'
+      }, {
+        propertyId: 22,
+        value: false
+      }]
+    })
+
+    const submissionStatus = page.getByRole('status')
+
+    await expect(submissionStatus).toContainText('Submitted for review.')
+    await expect(submissionStatus).toBeFocused()
+    await expect(page.getByRole('button', { name: 'Submit for review' })).toHaveCount(0)
+    await expect(page.locator(`a[href*="${pendingItemId}"]`)).toHaveCount(0)
+    expect(getMyGearPostCount()).toBe(0)
+  })
+
+  test('should preserve the form after a failed submit and allow retry', async ({ context, page }) => {
+    const submitResponder = createRetryingSubmitResponder()
+
+    await mockSubmissionApi(context, {
+      submit: submitResponder.respond
+    })
+    await openRegisteredSubmissionPage(context, page)
+    await fillBaseFields(page)
+    await page.getByLabel('Weight').fill('83.5')
+    await page.getByRole('button', { name: 'Submit for review' }).click()
+
+    await expect(page.getByText('Could not submit item. Try again.')).toBeVisible()
+    await expect(page.getByLabel('Item name')).toHaveValue('PocketRocket Deluxe')
+    await expect(page.getByLabel('Weight')).toHaveValue('83.5')
+
+    await page.getByRole('button', { name: 'Submit for review' }).click()
+
+    await expect(page.getByRole('status')).toContainText('Submitted for review.')
+    expect(submitResponder.getRequestCount()).toBe(2)
+  })
+
+  test('should reset the form and allow another submission after success', async ({ context, page }) => {
+    await mockSubmissionApi(context)
+    await openRegisteredSubmissionPage(context, page)
+    await fillBaseFields(page)
+    await page.getByLabel('Weight').fill('83.5')
+
+    const firstSubmissionRequestPromise = page.waitForRequest(isSubmissionRequest)
+
+    await page.getByRole('button', { name: 'Submit for review' }).click()
+    await firstSubmissionRequestPromise
+    await expect(page.getByRole('status')).toContainText('Submitted for review.')
+    await page.getByRole('button', { name: 'Submit another item' }).click()
+
+    await expect(page.getByLabel('Item name')).toHaveValue('')
+    await expect(page.getByLabel('Item name')).toBeFocused()
+    await expect(getSelect(page, 'Brand')).toHaveAttribute('data-value', '')
+    await expect(getSelect(page, 'Category')).toHaveAttribute('data-value', '')
+    await expect(page.getByLabel('Weight')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Submit for review' })).toBeDisabled()
+
+    await fillBaseFields(page)
+    await page.getByLabel('Item name').fill('PocketRocket 2')
+    await expect(page.getByLabel('Weight')).toHaveValue('')
+
+    const secondSubmissionRequestPromise = page.waitForRequest(isSubmissionRequest)
+
+    await page.getByRole('button', { name: 'Submit for review' }).click()
+
+    const secondSubmissionRequest = await secondSubmissionRequestPromise
+    const secondRequestBody: unknown = secondSubmissionRequest.postDataJSON()
+
+    expect(secondRequestBody).toStrictEqual({
+      brandId: 10,
+      categoryId: 2,
+      name: 'PocketRocket 2',
+      properties: []
+    })
+    await expect(page.getByRole('status')).toContainText('Submitted for review.')
+  })
+
+  test('should retry failed category details but allow a base-only submission', async ({
+    context,
+    page
+  }) => {
+    let categoryRequestCount = 0
+
+    await mockSubmissionApi(context, {
+      categoryDetail: async (route) => {
+        categoryRequestCount += 1
+        await route.fulfill({ status: 500, json: { statusCode: 500 } })
+      }
+    })
+    await openRegisteredSubmissionPage(context, page)
+    await fillBaseFields(page)
+
+    await expect(page.getByText(/Could not load characteristics/u)).toBeVisible()
+    const categoryRequestCountBeforeRetry = categoryRequestCount
+
+    await page.getByRole('button', { name: 'Retry' }).click()
+    await expect.poll(() => categoryRequestCount).toBeGreaterThan(categoryRequestCountBeforeRetry)
+
+    const submissionRequestPromise = page.waitForRequest(isSubmissionRequest)
+
+    await page.getByRole('button', { name: 'Submit for review' }).click()
+
+    const submissionRequest = await submissionRequestPromise
+    const requestBody: unknown = submissionRequest.postDataJSON()
+
+    expect(requestBody).toStrictEqual({
+      brandId: 10,
+      categoryId: 2,
+      name: 'PocketRocket Deluxe',
+      properties: []
+    })
+  })
+
+  test('should abort stale category details and show only the latest category fields', async ({
+    context,
+    page
+  }) => {
+    const staleRouteGate = createDeferred()
+
+    await mockSubmissionApi(context, {
+      categoryDetail: createStaleCategoryResponder(staleRouteGate.promise)
+    })
+    await openRegisteredSubmissionPage(context, page)
+
+    const staleRequestFailedPromise = page.waitForEvent(
+      'requestfailed',
+      (request) => request.url().endsWith('/api/equipment/categories/by-slug/stoves')
+    )
+
+    await selectPerdOption(getSelect(page, 'Category'), 'stoves')
+    await selectPerdOption(getSelect(page, 'Category'), 'sleeping-pads')
+
+    const staleRequest = await staleRequestFailedPromise
+
+    expect(staleRequest.failure()?.errorText).toContain('ERR_ABORTED')
+    staleRouteGate.resolve()
+    await expect(page.getByLabel('R-value')).toBeVisible()
+    await expect(page.getByLabel('Weight')).toHaveCount(0)
+  })
+})

--- a/tests/playwright/login/login.test.ts
+++ b/tests/playwright/login/login.test.ts
@@ -45,6 +45,7 @@ test.describe('Login page', () => {
         status: 201,
 
         json: {
+          isGuest: true,
           userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7'
         }
       })
@@ -105,7 +106,8 @@ test.describe('Login page', () => {
       await route.fulfill({
         json: {
           userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477d7',
-          isAdmin: false
+          isAdmin: false,
+          isGuest: false
         }
       })
     })

--- a/tests/playwright/packing-lists/packing-list-shell.test.ts
+++ b/tests/playwright/packing-lists/packing-list-shell.test.ts
@@ -404,6 +404,7 @@ async function mockAuth(context: BrowserContext): Promise<void> {
       status: 201,
 
       json: {
+        isGuest: true,
         userId: '0195f6e8-8f44-74f6-bc9a-5c8f7df477aa'
       }
     })

--- a/tools/__tests__/seed-catalog.test.ts
+++ b/tools/__tests__/seed-catalog.test.ts
@@ -50,4 +50,19 @@ describe(buildCategoryPropertySeedRows, () => {
       expect(orderedProperties).toStrictEqual(expectedProperties)
     }
   })
+
+  it('should allow negative values only for the sleeping bag temperature rating', () => {
+    const categorySlugs = Object.keys(propertyDefinitionsByCategorySlug)
+    const categoryIdBySlug = new Map(categorySlugs.map((categorySlug, index) => [categorySlug, index + 1]))
+    const rows = buildCategoryPropertySeedRows(categoryIdBySlug)
+    const negativeValueRows = rows.filter((row) => row.allowsNegativeValues)
+    const sleepingBagsCategoryId = categoryIdBySlug.get('sleeping-bags')
+
+    expect(negativeValueRows).toStrictEqual([
+      expect.objectContaining({
+        categoryId: sleepingBagsCategoryId,
+        slug: 'temperature-rating'
+      })
+    ])
+  })
 })

--- a/tools/seed-catalog.ts
+++ b/tools/seed-catalog.ts
@@ -80,6 +80,7 @@ function buildCategoryPropertySeedRows(categoryIdBySlug: Map<string, number>) {
 
     return properties.map((property, displayOrder) => {
       return {
+        allowsNegativeValues: property.allowsNegativeValues ?? false,
         categoryId,
         dataType: property.dataType,
         displayOrder,

--- a/tools/seed-data.ts
+++ b/tools/seed-data.ts
@@ -8,6 +8,7 @@ interface EnumOptionDefinition {
 }
 
 interface PropertyDefinition {
+  allowsNegativeValues?: boolean;
   dataType: PropertyDataType;
   enumOptions?: EnumOptionDefinition[];
   name: string;
@@ -58,6 +59,7 @@ const brandDefinitions: ReferenceSeedDefinition[] = [
 const propertyDefinitionsByCategorySlug: Record<string, PropertyDefinition[]> = {
   'sleeping-bags': [
     {
+      allowsNegativeValues: true,
       dataType: 'number',
       name: 'Temperature Rating',
       slug: 'temperature-rating',


### PR DESCRIPTION
## Summary

Adds the missing-gear submission path without letting Guest sessions sneak into the review queue 💨😎 Registered accounts can now submit typed catalog data as pending items, while the UI keeps the whole flow clear and recoverable.

- ✨ Add a registered-account-only item-submission API with transactional pending item, property, and contribution writes
- 🔐 Derive Guest status from existing OAuth relationships and synchronize it across authentication responses and client state
- 🧭 Add the Gear library submission CTA, protected page, Guest placeholder, reference retries, and confirmation flow
- ♿ Add reusable text and number inputs, generated internal IDs, and focused accessibility fixes across affected UI
- ✅ Cover authentication, authorization, property normalization, migration behavior, submission APIs, and browser scenarios

## Motivation

Gear missing from the catalog needs a reviewable submission path, but anonymous Guest sessions must not create pending catalog records 🍎🍏

## Related issues

Fixes #718